### PR TITLE
Test cleanup

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,4 +1,3 @@
-import os
 from rocrate import rocrate_api as roc_api
 from rocrate.rocrate import ROCrate
 from test.test_common import BaseTest
@@ -7,21 +6,19 @@ from test.test_common import BaseTest
 class TestAPI(BaseTest):
 
     def test_galaxy_wf_crate(self):
-        wf_path = os.path.join(self.test_data_dir, 'test_galaxy_wf.ga')
+        wf_path = self.test_data_dir / 'test_galaxy_wf.ga'
         wc_crate = roc_api.make_workflow_rocrate(wf_path, wf_type='Galaxy')
         self.assertIsInstance(wc_crate, ROCrate)
 
     def test_cwl_wf_crate(self):
-        wf_path = os.path.join(self.test_data_dir, 'sample_cwl_wf.cwl')
+        wf_path = self.test_data_dir / 'sample_cwl_wf.cwl'
         wc_crate = roc_api.make_workflow_rocrate(wf_path, wf_type='CWL')
         self.assertIsInstance(wc_crate, ROCrate)
 
     def test_create_wf_include(self):
-        wf_path = os.path.join(self.test_data_dir, 'test_galaxy_wf.ga')
-        extra_file1 = os.path.join(self.test_data_dir, 'test_file_galaxy.txt')
-        extra_file2 = os.path.join(
-            self.test_data_dir, 'test_file_galaxy2.txt'
-        )
+        wf_path = self.test_data_dir / 'test_galaxy_wf.ga'
+        extra_file1 = self.test_data_dir / 'test_file_galaxy.txt'
+        extra_file2 = self.test_data_dir / 'test_file_galaxy2.txt'
         files_list = [extra_file1, extra_file2]
         wc_crate = roc_api.make_workflow_rocrate(
             wf_path, wf_type='Galaxy', include_files=files_list

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,26 +1,29 @@
-import unittest
 import os
 from rocrate import rocrate_api as roc_api
 from rocrate.rocrate import ROCrate
 from test.test_common import BaseTest
 
-class TestAPI(BaseTest):
 
+class TestAPI(BaseTest):
 
     def test_galaxy_wf_crate(self):
         wf_path = os.path.join(self.test_data_dir, 'test_galaxy_wf.ga')
-        wc_crate = roc_api.make_workflow_rocrate(wf_path,wf_type = 'Galaxy')
+        wc_crate = roc_api.make_workflow_rocrate(wf_path, wf_type='Galaxy')
         self.assertIsInstance(wc_crate, ROCrate)
 
     def test_cwl_wf_crate(self):
         wf_path = os.path.join(self.test_data_dir, 'sample_cwl_wf.cwl')
-        wc_crate = roc_api.make_workflow_rocrate(wf_path,wf_type = 'CWL')
+        wc_crate = roc_api.make_workflow_rocrate(wf_path, wf_type='CWL')
         self.assertIsInstance(wc_crate, ROCrate)
 
     def test_create_wf_include(self):
         wf_path = os.path.join(self.test_data_dir, 'test_galaxy_wf.ga')
         extra_file1 = os.path.join(self.test_data_dir, 'test_file_galaxy.txt')
-        extra_file2 =  os.path.join(self.test_data_dir, 'test_file_galaxy2.txt')
-        files_list = [extra_file1,extra_file2]
-        wc_crate = roc_api.make_workflow_rocrate(wf_path,wf_type = 'Galaxy', include_files = files_list)
+        extra_file2 = os.path.join(
+            self.test_data_dir, 'test_file_galaxy2.txt'
+        )
+        files_list = [extra_file1, extra_file2]
+        wc_crate = roc_api.make_workflow_rocrate(
+            wf_path, wf_type='Galaxy', include_files=files_list
+        )
         self.assertIsInstance(wc_crate, ROCrate)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,9 +1,7 @@
 import os
-import sys
 import shutil
 import tempfile
 import unittest
-
 
 
 class BaseTest(unittest.TestCase):
@@ -11,8 +9,11 @@ class BaseTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="rocrate_test_")
 
-        #copy test data
-        shutil.copytree(os.path.abspath(os.path.join('test', 'test-data')), os.path.join(self.tmpdir,'test-data'))
+        # copy test data
+        shutil.copytree(
+            os.path.abspath(os.path.join('test', 'test-data')),
+            os.path.join(self.tmpdir, 'test-data')
+        )
         self.test_data_dir = os.path.join(self.tmpdir, 'test-data')
         self.assertTrue(os.path.isdir(self.test_data_dir))
 

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,21 +1,19 @@
-import os
+import pathlib
 import shutil
 import tempfile
 import unittest
 
 
+THIS_DIR = pathlib.Path(__file__).absolute().parent
+TEST_DATA_NAME = 'test-data'
+
+
 class BaseTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpdir = tempfile.mkdtemp(prefix="rocrate_test_")
-
-        # copy test data
-        shutil.copytree(
-            os.path.abspath(os.path.join('test', 'test-data')),
-            os.path.join(self.tmpdir, 'test-data')
-        )
-        self.test_data_dir = os.path.join(self.tmpdir, 'test-data')
-        self.assertTrue(os.path.isdir(self.test_data_dir))
+        self.tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="rocrate_test_"))
+        self.test_data_dir = self.tmpdir / TEST_DATA_NAME
+        shutil.copytree(THIS_DIR / TEST_DATA_NAME, self.test_data_dir)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,12 +1,11 @@
-import unittest
 import os
 from rocrate.rocrate import ROCrate
 from rocrate.model.file import File
 from rocrate.model.person import Person
 from test.test_common import BaseTest
 
-class TestAPI(BaseTest):
 
+class TestAPI(BaseTest):
 
     def test_dereferencing(self):
         crate = ROCrate()
@@ -23,7 +22,7 @@ class TestAPI(BaseTest):
         self.assertIsInstance(file_returned, File)
         dereference_file = crate.dereference("sample_file.txt")
         self.assertIsInstance(dereference_file, File)
-        self.assertEqual(file_returned,dereference_file)
+        self.assertEqual(file_returned, dereference_file)
 
     def test_dereferencing_equivalent_id(self):
         crate = ROCrate()
@@ -40,24 +39,22 @@ class TestAPI(BaseTest):
 
     def test_contextual_entities(self):
         crate = ROCrate()
-        new_person = crate.add_person('joe' , {'name': 'Joe Pesci'})
+        new_person = crate.add_person('joe', {'name': 'Joe Pesci'})
         person_dereference = crate.dereference('#joe')
         person_prop = person_dereference.properties()
         self.assertEqual(person_prop['@type'], 'Person')
         self.assertEqual(person_prop['name'], 'Joe Pesci')
+        self.assertEqual(new_person.properties(), person_prop)
 
     def test_properties(self):
         crate = ROCrate()
 
-        new_person = crate.add_person('001' , {'name': 'Lee Ritenour'})
+        new_person = crate.add_person('001', {'name': 'Lee Ritenour'})
         crate.creator = new_person
         self.assertIsInstance(crate.creator, Person)
         self.assertEqual(crate.creator['name'], 'Lee Ritenour')
 
-        new_person2 = crate.add_person('002' , {'name': 'Lee Ritenour'})
+        new_person2 = crate.add_person('002', {'name': 'Lee Ritenour'})
 
-        crate.creator = [new_person,new_person2]
-        self.assertIsInstance(crate.creator,list)
-
-
-
+        crate.creator = [new_person, new_person2]
+        self.assertIsInstance(crate.creator, list)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,4 +1,3 @@
-import os
 from rocrate.rocrate import ROCrate
 from rocrate.model.file import File
 from rocrate.model.person import Person
@@ -17,7 +16,7 @@ class TestAPI(BaseTest):
         self.assertEqual(metadata_entity, crate.metadata)
 
         # dereference added files
-        sample_file = os.path.join(self.test_data_dir, 'sample_file.txt')
+        sample_file = self.test_data_dir / 'sample_file.txt'
         file_returned = crate.add_file(sample_file)
         self.assertIsInstance(file_returned, File)
         dereference_file = crate.dereference("sample_file.txt")

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,4 +1,3 @@
-import os
 from rocrate.rocrate import ROCrate
 from test.test_common import BaseTest
 import tempfile
@@ -9,7 +8,7 @@ class TestAPI(BaseTest):
 
     def test_crate_dir_loading(self):
         # load crate from directory
-        crate_dir = os.path.join(self.test_data_dir, 'read_crate')
+        crate_dir = self.test_data_dir / 'read_crate'
         crate = ROCrate(crate_dir, load_preview=True)
 
         # check loaded entities and properties
@@ -23,12 +22,9 @@ class TestAPI(BaseTest):
         self.assertEqual(author_prop['name'], 'Joe Bloggs')
 
         # write the crate in a different directory
-        out_path = os.path.join(tempfile.gettempdir(), 'crate_read_out')
-        if not os.path.exists(out_path):
-            os.mkdir(out_path)
+        out_path = pathlib.Path(tempfile.gettempdir()) / 'crate_read_out'
+        out_path.mkdir(exist_ok=True)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(
-            os.path.join(out_path, 'ro-crate-metadata.jsonld')
-        )
+        metadata_path = out_path / 'ro-crate-metadata.jsonld'
         self.assertTrue(metadata_path.exists())

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,13 +1,9 @@
-import unittest
 import os
 from rocrate.rocrate import ROCrate
-from rocrate.model.file import File
-from rocrate.model.person import Person
 from test.test_common import BaseTest
 import tempfile
 import pathlib
-import zipfile
-import shutil
+
 
 class TestAPI(BaseTest):
 
@@ -16,9 +12,10 @@ class TestAPI(BaseTest):
         crate_dir = os.path.join(self.test_data_dir, 'read_crate')
         crate = ROCrate(crate_dir, load_preview=True)
 
-        #check loaded entities and properties
+        # check loaded entities and properties
         main_wf = crate.dereference('test_galaxy_wf.ga')
         wf_prop = main_wf.properties()
+        self.assertEqual(wf_prop['@id'], 'test_galaxy_wf.ga')
 
         wf_author = crate.dereference('#joe')
         author_prop = wf_author.properties()
@@ -26,44 +23,12 @@ class TestAPI(BaseTest):
         self.assertEqual(author_prop['name'], 'Joe Bloggs')
 
         # write the crate in a different directory
-        out_path = os.path.join(tempfile.gettempdir(),'crate_read_out')
+        out_path = os.path.join(tempfile.gettempdir(), 'crate_read_out')
         if not os.path.exists(out_path):
             os.mkdir(out_path)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(os.path.join(out_path, 'ro-crate-metadata.jsonld'))
+        metadata_path = pathlib.Path(
+            os.path.join(out_path, 'ro-crate-metadata.jsonld')
+        )
         self.assertTrue(metadata_path.exists())
-
-
-
-
-        # metadata_path = pathlib.Path(os.path.join(out_path, 'ro-crate-metadata.jsonld'))
-        # self.assertTrue(metadata_path.exists())
-
-        # preview_path = pathlib.Path(os.path.join(out_path, 'ro-crate-preview.html'))
-        # self.assertTrue(preview_path.exists())
-        # file1 = pathlib.Path(os.path.join(out_path, 'sample_file.txt'))
-        # file2 = pathlib.Path(os.path.join(out_path, 'subdir','sample_file2.csv'))
-        # file_subdir = pathlib.Path(os.path.join(out_path, 'test_add_dir','sample_file_subdir.txt'))
-        # self.assertTrue(file1.exists())
-        # self.assertTrue(file2.exists())
-        # self.assertTrue(file_subdir.exists())
-
-
-    # def test_write_zip(self):
-        # crate = ROCrate()
-
-        # # dereference added files
-        # sample_file = os.path.join(self.test_data_dir, 'sample_file.txt')
-        # file_returned = crate.add_file(sample_file)
-        # file_returned_subdir = crate.add_file(sample_file, 'subdir/sample_file2.csv')
-        # test_dir_path = os.path.join(self.test_data_dir,'test_add_dir')
-        # test_dir_entity = crate.add_directory(test_dir_path, 'test_add_dir')
-
-        # #write to zip
-        # zip_path = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.zip')
-        # crate.write_zip(zip_path.name)
-        # zip_path.close()
-        # read_zip = zipfile.ZipFile(zip_path.name, mode='r')
-        # self.assertEqual(read_zip.getinfo('sample_file.txt').file_size, 12)
-        # self.assertEqual(read_zip.getinfo('test_add_dir/sample_file_subdir.txt').file_size, 18)

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1,5 +1,4 @@
 import io
-import os
 from rocrate.rocrate import ROCrate
 from test.test_common import BaseTest
 import tempfile
@@ -12,43 +11,34 @@ class TestWrite(BaseTest):
     def test_file_writing(self):
         crate = ROCrate()
         # dereference added files
-        sample_file = os.path.join(self.test_data_dir, 'sample_file.txt')
+        sample_file = self.test_data_dir / 'sample_file.txt'
         file_returned = crate.add_file(sample_file)
         self.assertEqual(file_returned.id, 'sample_file.txt')
         file_returned_subdir = crate.add_file(
             sample_file, 'subdir/sample_file2.csv'
         )
         self.assertEqual(file_returned_subdir.id, 'subdir/sample_file2.csv')
-        test_dir_path = os.path.join(self.test_data_dir, 'test_add_dir')
+        test_dir_path = self.test_data_dir / 'test_add_dir'
         test_dir_entity = crate.add_directory(test_dir_path, 'test_add_dir')
         self.assertTrue(test_dir_entity is None)  # is this intended?
-        out_path = os.path.join(tempfile.gettempdir(), 'ro_crate_out')
+        out_path = pathlib.Path(tempfile.gettempdir()) / 'ro_crate_out'
 
         crate.name = 'Test crate'
 
         new_person = crate.add_person('001', {'name': 'Lee Ritenour'})
         crate.creator = new_person
 
-        if not os.path.exists(out_path):
-            os.mkdir(out_path)
+        out_path.mkdir(exist_ok=True)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(
-            os.path.join(out_path, 'ro-crate-metadata.jsonld')
-        )
+        metadata_path = out_path / 'ro-crate-metadata.jsonld'
         self.assertTrue(metadata_path.exists())
 
-        preview_path = pathlib.Path(
-            os.path.join(out_path, 'ro-crate-preview.html')
-        )
+        preview_path = out_path / 'ro-crate-preview.html'
         self.assertTrue(preview_path.exists())
-        file1 = pathlib.Path(os.path.join(out_path, 'sample_file.txt'))
-        file2 = pathlib.Path(
-            os.path.join(out_path, 'subdir', 'sample_file2.csv')
-        )
-        file_subdir = pathlib.Path(
-            os.path.join(out_path, 'test_add_dir', 'sample_file_subdir.txt')
-        )
+        file1 = out_path / 'sample_file.txt'
+        file2 = out_path / 'subdir' / 'sample_file2.csv'
+        file_subdir = out_path / 'test_add_dir' / 'sample_file_subdir.txt'
         self.assertTrue(file1.exists())
         self.assertTrue(file2.exists())
         self.assertTrue(file_subdir.exists())
@@ -60,25 +50,20 @@ class TestWrite(BaseTest):
         file_stringio = io.StringIO(file_content)
         file_returned = crate.add_file(file_stringio, 'test_file.txt')
         self.assertEqual(file_returned.id, 'test_file.txt')
-        out_path = os.path.join(tempfile.gettempdir(), 'ro_crate_out')
+        out_path = pathlib.Path(tempfile.gettempdir()) / 'ro_crate_out'
         crate.name = 'Test crate'
 
-        if not os.path.exists(out_path):
-            os.mkdir(out_path)
+        out_path.mkdir(exist_ok=True)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(
-            os.path.join(out_path, 'ro-crate-metadata.jsonld')
-        )
+        metadata_path = out_path / 'ro-crate-metadata.jsonld'
         self.assertTrue(metadata_path.exists())
 
-        preview_path = pathlib.Path(
-            os.path.join(out_path, 'ro-crate-preview.html')
-        )
+        preview_path = out_path / 'ro-crate-preview.html'
         self.assertTrue(preview_path.exists())
-        file1 = pathlib.Path(os.path.join(out_path, 'test_file.txt'))
+        file1 = out_path / 'test_file.txt'
         self.assertTrue(file1.exists())
-        self.assertEqual(os.path.getsize(file1), 36)
+        self.assertEqual(file1.stat().st_size, 36)
 
     def test_remote_uri(self):
         crate = ROCrate()
@@ -88,32 +73,29 @@ class TestWrite(BaseTest):
         self.assertEqual(file_returned.id, 'sample_file.txt')
         file_returned = crate.add_file(source=url, fetch_remote=False)
         self.assertEqual(file_returned.id, url)
-        out_path = os.path.join(tempfile.gettempdir(), 'ro_crate_out')
+        out_path = pathlib.Path(tempfile.gettempdir()) / 'ro_crate_out'
 
-        if not os.path.exists(out_path):
-            os.mkdir(out_path)
+        out_path.mkdir(exist_ok=True)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(
-            os.path.join(out_path, 'ro-crate-metadata.jsonld')
-        )
+        metadata_path = out_path / 'ro-crate-metadata.jsonld'
         self.assertTrue(metadata_path.exists())
 
-        file1 = pathlib.Path(os.path.join(out_path, 'sample_file.txt'))
+        file1 = out_path / 'sample_file.txt'
         self.assertTrue(file1.exists())
 
     def test_write_zip(self):
         crate = ROCrate()
 
         # dereference added files
-        sample_file = os.path.join(self.test_data_dir, 'sample_file.txt')
+        sample_file = self.test_data_dir / 'sample_file.txt'
         file_returned = crate.add_file(sample_file)
         self.assertEqual(file_returned.id, 'sample_file.txt')
         file_returned_subdir = crate.add_file(
             sample_file, 'subdir/sample_file2.csv'
         )
         self.assertEqual(file_returned_subdir.id, 'subdir/sample_file2.csv')
-        test_dir_path = os.path.join(self.test_data_dir, 'test_add_dir')
+        test_dir_path = self.test_data_dir / 'test_add_dir'
         test_dir_entity = crate.add_directory(test_dir_path, 'test_add_dir')
         self.assertTrue(test_dir_entity is None)  # is this intended?
         # write to zip

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1,14 +1,11 @@
 import io
-import unittest
 import os
 from rocrate.rocrate import ROCrate
-from rocrate.model.file import File
-from rocrate.model.person import Person
 from test.test_common import BaseTest
 import tempfile
 import pathlib
 import zipfile
-import shutil
+
 
 class TestWrite(BaseTest):
 
@@ -17,28 +14,41 @@ class TestWrite(BaseTest):
         # dereference added files
         sample_file = os.path.join(self.test_data_dir, 'sample_file.txt')
         file_returned = crate.add_file(sample_file)
-        file_returned_subdir = crate.add_file(sample_file, 'subdir/sample_file2.csv')
-        test_dir_path = os.path.join(self.test_data_dir,'test_add_dir')
+        self.assertEqual(file_returned.id, 'sample_file.txt')
+        file_returned_subdir = crate.add_file(
+            sample_file, 'subdir/sample_file2.csv'
+        )
+        self.assertEqual(file_returned_subdir.id, 'subdir/sample_file2.csv')
+        test_dir_path = os.path.join(self.test_data_dir, 'test_add_dir')
         test_dir_entity = crate.add_directory(test_dir_path, 'test_add_dir')
-        out_path = os.path.join(tempfile.gettempdir(),'ro_crate_out')
+        self.assertTrue(test_dir_entity is None)  # is this intended?
+        out_path = os.path.join(tempfile.gettempdir(), 'ro_crate_out')
 
         crate.name = 'Test crate'
 
-        new_person = crate.add_person('001' , {'name': 'Lee Ritenour'})
+        new_person = crate.add_person('001', {'name': 'Lee Ritenour'})
         crate.creator = new_person
 
         if not os.path.exists(out_path):
             os.mkdir(out_path)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(os.path.join(out_path, 'ro-crate-metadata.jsonld'))
+        metadata_path = pathlib.Path(
+            os.path.join(out_path, 'ro-crate-metadata.jsonld')
+        )
         self.assertTrue(metadata_path.exists())
 
-        preview_path = pathlib.Path(os.path.join(out_path, 'ro-crate-preview.html'))
+        preview_path = pathlib.Path(
+            os.path.join(out_path, 'ro-crate-preview.html')
+        )
         self.assertTrue(preview_path.exists())
         file1 = pathlib.Path(os.path.join(out_path, 'sample_file.txt'))
-        file2 = pathlib.Path(os.path.join(out_path, 'subdir','sample_file2.csv'))
-        file_subdir = pathlib.Path(os.path.join(out_path, 'test_add_dir','sample_file_subdir.txt'))
+        file2 = pathlib.Path(
+            os.path.join(out_path, 'subdir', 'sample_file2.csv')
+        )
+        file_subdir = pathlib.Path(
+            os.path.join(out_path, 'test_add_dir', 'sample_file_subdir.txt')
+        )
         self.assertTrue(file1.exists())
         self.assertTrue(file2.exists())
         self.assertTrue(file_subdir.exists())
@@ -48,18 +58,23 @@ class TestWrite(BaseTest):
         # dereference added files
         file_content = 'This will be the content of the file'
         file_stringio = io.StringIO(file_content)
-        file_returned = crate.add_file(file_stringio,'test_file.txt')
-        out_path = os.path.join(tempfile.gettempdir(),'ro_crate_out')
+        file_returned = crate.add_file(file_stringio, 'test_file.txt')
+        self.assertEqual(file_returned.id, 'test_file.txt')
+        out_path = os.path.join(tempfile.gettempdir(), 'ro_crate_out')
         crate.name = 'Test crate'
 
         if not os.path.exists(out_path):
             os.mkdir(out_path)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(os.path.join(out_path, 'ro-crate-metadata.jsonld'))
+        metadata_path = pathlib.Path(
+            os.path.join(out_path, 'ro-crate-metadata.jsonld')
+        )
         self.assertTrue(metadata_path.exists())
 
-        preview_path = pathlib.Path(os.path.join(out_path, 'ro-crate-preview.html'))
+        preview_path = pathlib.Path(
+            os.path.join(out_path, 'ro-crate-preview.html')
+        )
         self.assertTrue(preview_path.exists())
         file1 = pathlib.Path(os.path.join(out_path, 'test_file.txt'))
         self.assertTrue(file1.exists())
@@ -67,16 +82,21 @@ class TestWrite(BaseTest):
 
     def test_remote_uri(self):
         crate = ROCrate()
-        url = 'https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/sample_file.txt'
-        file_returned = crate.add_file(source=url, fetch_remote = True)
-        file_returned = crate.add_file(source=url, fetch_remote = False)
-        out_path = os.path.join(tempfile.gettempdir(),'ro_crate_out')
+        url = ('https://raw.githubusercontent.com/ResearchObject/ro-crate-py/'
+               'master/test/test-data/sample_file.txt')
+        file_returned = crate.add_file(source=url, fetch_remote=True)
+        self.assertEqual(file_returned.id, 'sample_file.txt')
+        file_returned = crate.add_file(source=url, fetch_remote=False)
+        self.assertEqual(file_returned.id, url)
+        out_path = os.path.join(tempfile.gettempdir(), 'ro_crate_out')
 
         if not os.path.exists(out_path):
             os.mkdir(out_path)
         crate.write_crate(out_path)
 
-        metadata_path = pathlib.Path(os.path.join(out_path, 'ro-crate-metadata.jsonld'))
+        metadata_path = pathlib.Path(
+            os.path.join(out_path, 'ro-crate-metadata.jsonld')
+        )
         self.assertTrue(metadata_path.exists())
 
         file1 = pathlib.Path(os.path.join(out_path, 'sample_file.txt'))
@@ -88,14 +108,23 @@ class TestWrite(BaseTest):
         # dereference added files
         sample_file = os.path.join(self.test_data_dir, 'sample_file.txt')
         file_returned = crate.add_file(sample_file)
-        file_returned_subdir = crate.add_file(sample_file, 'subdir/sample_file2.csv')
-        test_dir_path = os.path.join(self.test_data_dir,'test_add_dir')
+        self.assertEqual(file_returned.id, 'sample_file.txt')
+        file_returned_subdir = crate.add_file(
+            sample_file, 'subdir/sample_file2.csv'
+        )
+        self.assertEqual(file_returned_subdir.id, 'subdir/sample_file2.csv')
+        test_dir_path = os.path.join(self.test_data_dir, 'test_add_dir')
         test_dir_entity = crate.add_directory(test_dir_path, 'test_add_dir')
-
-        #write to zip
-        zip_path = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.zip')
+        self.assertTrue(test_dir_entity is None)  # is this intended?
+        # write to zip
+        zip_path = tempfile.NamedTemporaryFile(
+            mode='w', delete=False, suffix='.zip'
+        )
         crate.write_zip(zip_path.name)
         zip_path.close()
         read_zip = zipfile.ZipFile(zip_path.name, mode='r')
         self.assertEqual(read_zip.getinfo('sample_file.txt').file_size, 12)
-        self.assertEqual(read_zip.getinfo('test_add_dir/sample_file_subdir.txt').file_size, 18)
+        self.assertEqual(
+            read_zip.getinfo('test_add_dir/sample_file_subdir.txt').file_size,
+            18
+        )


### PR DESCRIPTION
Clean up test code: remove unused imports, fix other PEP8 violations, etc.

Also changed to use `pathlib` consistently across the whole test code.