### PR TITLE
Test metadata

### DIFF
--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -266,6 +266,20 @@ class ROCrate():
     def CreativeWorkStatus(self, value):
         self.root_dataset['CreativeWorkStatus'] = value
 
+    @property
+    def test_dir(self):
+        rval = self.dereference("test")
+        if rval and "Dataset" in rval.type:
+            return rval
+        return None
+
+    @property
+    def examples_dir(self):
+        rval = self.dereference("examples")
+        if rval and "Dataset" in rval.type:
+            return rval
+        return None
+
     def resolve_id(self, relative_id):
         return generate.arcp_random(relative_id.strip('./'), uuid=self.uuid)
 

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -35,6 +35,9 @@ from .model.preview import Preview
 from arcp import generate
 
 
+TEST_METADATA_BASENAME = "test-metadata.json"
+
+
 class ROCrate():
 
     def __init__(self, source_path=None, load_preview=False):
@@ -279,6 +282,12 @@ class ROCrate():
         if rval and "Dataset" in rval.type:
             return rval
         return None
+
+    @property
+    def test_metadata_path(self):
+        if self.test_dir is None:
+            return None
+        return Path(self.test_dir.filepath()) / TEST_METADATA_BASENAME
 
     def resolve_id(self, relative_id):
         return generate.arcp_random(relative_id.strip('./'), uuid=self.uuid)

--- a/test/test-data/read_crate/ro-crate-metadata.jsonld
+++ b/test/test-data/read_crate/ro-crate-metadata.jsonld
@@ -30,6 +30,9 @@
                 },
                 {
                     "@id": "examples/"
+                },
+                {
+                    "@id": "test/"
                 }
             ],
             "mainEntity": {
@@ -80,6 +83,10 @@
         },
         {
             "@id": "examples/",
+            "@type": "Dataset"
+        },
+        {
+            "@id": "test/",
             "@type": "Dataset"
         }
     ]

--- a/test/test-data/read_crate/test/test-metadata.json
+++ b/test/test-data/read_crate/test/test-metadata.json
@@ -1,0 +1,19 @@
+{
+    "tmpformat": "ro/workflow/test-metadata/0.1",
+    "@id": "test-metadata.json",
+    "test": [
+        {
+            "name": "test1",
+            "instance": [
+                {
+                    "name": "example_jenkins",
+                    "service": {
+                        "type": "jenkins",
+                        "url": "http://example.org/jenkins",
+                        "resource": "job/tests/"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -77,6 +77,7 @@ def test_crate_dir_loading(test_data_dir, tmpdir, helpers, load_preview):
     dataset_prop = dataset.properties()
     assert dataset_prop['@id'] == 'examples/'
     assert dataset_prop['@id'] == dataset.id
+    assert crate.examples_dir is dataset
 
     # write the crate in a different directory
     out_path = tmpdir / 'crate_read_out'

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,6 +1,7 @@
 import pytest
+from pathlib import Path
 
-from rocrate.rocrate import ROCrate
+from rocrate.rocrate import ROCrate, TEST_METADATA_BASENAME
 
 _URL = ('https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/'
         'test/test-data/sample_file.txt')
@@ -84,6 +85,7 @@ def test_crate_dir_loading(test_data_dir, tmpdir, helpers, load_preview):
     assert test_dataset_prop['@id'] == 'test/'
     assert test_dataset_prop['@id'] == test_dataset.id
     assert crate.test_dir is test_dataset
+    assert crate.test_metadata_path == Path("test") / TEST_METADATA_BASENAME
 
     # write the crate in a different directory
     out_path = tmpdir / 'crate_read_out'

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -73,11 +73,17 @@ def test_crate_dir_loading(test_data_dir, tmpdir, helpers, load_preview):
     assert remote_file_prop['@id'] == _URL
     assert remote_file_prop['@id'] == remote_file.id
 
-    dataset = crate.dereference('examples/')
-    dataset_prop = dataset.properties()
-    assert dataset_prop['@id'] == 'examples/'
-    assert dataset_prop['@id'] == dataset.id
-    assert crate.examples_dir is dataset
+    examples_dataset = crate.dereference('examples/')
+    examples_dataset_prop = examples_dataset.properties()
+    assert examples_dataset_prop['@id'] == 'examples/'
+    assert examples_dataset_prop['@id'] == examples_dataset.id
+    assert crate.examples_dir is examples_dataset
+
+    test_dataset = crate.dereference('test/')
+    test_dataset_prop = test_dataset.properties()
+    assert test_dataset_prop['@id'] == 'test/'
+    assert test_dataset_prop['@id'] == test_dataset.id
+    assert crate.test_dir is test_dataset
 
     # write the crate in a different directory
     out_path = tmpdir / 'crate_read_out'


### PR DESCRIPTION
Adds support for `test` and `examples` directories and test metadata file. See:

https://github.com/workflowhub-eu/about/blob/master/Workflow-RO-Crate.md
https://github.com/crs4/life_monitor/wiki/Test-Metadata-Draft-Spec

