### PR TITLE
File fixes

### DIFF
--- a/test/test_write.py
+++ b/test/test_write.py
@@ -18,6 +18,7 @@
 import io
 import pytest
 import sys
+import uuid
 import zipfile
 from urllib.error import URLError
 
@@ -143,7 +144,7 @@ def test_remote_uri(tmpdir, helpers, fetch_remote):
 def test_remote_uri_exceptions(tmpdir):
     crate = ROCrate()
     url = ('https://raw.githubusercontent.com/ResearchObject/ro-crate-py/'
-           'master/test/test-data/_do_not_create_this_.foo')
+           f'master/test/test-data/{uuid.uuid4().hex}.foo')
     crate.add_file(source=url, fetch_remote=True)
     out_path = tmpdir / 'ro_crate_out_1'
     out_path.mkdir()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -160,3 +160,28 @@ def test_remote_uri_exceptions(tmpdir):
     (out_path / "a").mkdir(mode=0o444)
     with pytest.raises(PermissionError):
         crate.write_crate(out_path)
+
+
+@pytest.mark.parametrize("fetch_remote,validate_url", [(False, False), (False, True), (True, False), (True, True)])
+def test_missing_source(test_data_dir, fetch_remote, validate_url):
+    crate = ROCrate()
+    path = test_data_dir / uuid.uuid4().hex
+    with pytest.raises(ValueError):
+        crate.add_file(str(path), fetch_remote=fetch_remote, validate_url=validate_url)
+
+    with pytest.raises(ValueError):
+        crate.add_file(str(path), path.name, fetch_remote=fetch_remote, validate_url=validate_url)
+
+
+@pytest.mark.parametrize("fetch_remote,validate_url", [(False, False), (False, True), (True, False), (True, True)])
+def test_stringio_no_dest(test_data_dir, fetch_remote, validate_url):
+    crate = ROCrate()
+    with pytest.raises(ValueError):
+        crate.add_file(io.StringIO("foo"))
+
+
+@pytest.mark.parametrize("fetch_remote,validate_url", [(False, False), (False, True), (True, False), (True, True)])
+def test_no_source_no_dest(test_data_dir, fetch_remote, validate_url):
+    crate = ROCrate()
+    with pytest.raises(ValueError):
+        crate.add_file()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -140,7 +140,7 @@ def test_remote_uri(tmpdir, helpers, fetch_remote):
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="dir mode has no effect on Windows")
-def test_remote_uri_exceptions(tmpdir, helpers):
+def test_remote_uri_exceptions(tmpdir):
     crate = ROCrate()
     url = ('https://raw.githubusercontent.com/ResearchObject/ro-crate-py/'
            'master/test/test-data/_do_not_create_this_.foo')


### PR DESCRIPTION
Fixes some problems with the handling of `source` and `dest_path` in `File`.

#### Nonexistent path as source and `dest_path` not `None`:
* **before**: a File entity with `dest_path` as the id was added to the metadata, but no file was added to the output crate upon writing
* **now**: raise `ValueError(f"'{source}' is not a path to a local file or a valid remote URI")`

Note that the `ValueError` is also raised with a nonexistent path as source and `dest_path` set to `None`, but this case was already being handled correctly.

#### `dest_path` set to `None` and source set to a `StringIO` or to `None`:
* **before**: `TypeError` from `os.path.isfile`
* **now**: raise `ValueError("dest_path must be provided if source is not a path or URI")`
