### PR TITLE
Add `$(VENV_DIR)` to `.PHONY` Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ test: $(VENV_DIR)/bin/pytest install
 clean:
 	git clean -fdx -e $(VENV_DIR)
 
-.PHONY: init-venv install lint test clean
+.PHONY: init-venv install lint test clean $(VENV_DIR)


### PR DESCRIPTION
Since the `$(VENV_DIR)` rule in the Makefile isn't really expected to create the directory, it needs to be marked as .PHONY (else it may not be executed). 