### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.1.0
+message: "Cite as"
+authors:
+  - family-names: Droesbeke
+    given-names: Bert
+    orcid: https://orcid.org/0000-0003-0522-5674
+  - family-names: Eguinoa
+    given-names: Ignacio
+    orcid: https://orcid.org/0000-0002-6190-122X
+  - family-names: Gaignard
+    given-names: Alban
+    orcid: https://orcid.org/0000-0002-3597-8557
+  - family-names: Leo
+    given-names: Simone
+    orcid: https://orcid.org/0000-0001-8271-5429
+  - family-names: Rodríguez-Navas
+    given-names: Laura
+    orcid: https://orcid.org/0000-0003-4929-1219
+  - family-names: Soiland-Reyes
+    given-names: Stian
+    orcid: https://orcid.org/0000-0001-9842-9718
+title: "ro-crate-py"
+version: 0.4.0
+doi: 10.5281/zenodo.4705143
+date-released: 2021-04-20


### PR DESCRIPTION
Adds [CITATION.cff](https://citation-file-format.github.io) to the repo. This is [now supported by GitHub](https://twitter.com/natfriedman/status/1420122675813441540).

All should review this, especially to check if I got the ORCIDs right.

At some point we should review and single-source all this information. This file looks like the best source for authors, since it contains more information and it's structured; OTOH, the release date should probably be generated upon tagging.