### PR TITLE
Allow metadata to reference missing files or directories

### DIFF
--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -44,7 +44,7 @@ class File(DataEntity):
             identifier = Path(dest_path).as_posix()  # relative path?
         else:
             # if there is no dest_path there must be a URI/local path as source
-            if not(is_url(str(source))):
+            if not is_url(str(source)):
                 # local source -> becomes local reference = reference relative
                 # to ro-crate root
                 identifier = os.path.basename(source)

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -269,3 +269,32 @@ def test_extra_data(test_data_dir, tmpdir, to_zip):
         assert (out_path / rel).is_file()
         with open(crate_dir / rel) as f1, open(out_path / rel) as f2:
             assert f1.read() == f2.read()
+
+
+def test_missing_dir(test_data_dir, tmpdir):
+    crate_dir = test_data_dir / 'read_crate'
+    name = 'examples'
+    shutil.rmtree(crate_dir / name)
+    crate = ROCrate(crate_dir)
+
+    examples_dataset = crate.dereference(name)
+    assert examples_dataset.id == f'{name}/'
+
+    out_path = tmpdir / 'crate_read_out'
+    crate.write_crate(out_path)
+    assert not (out_path / 'README.txt').exists()
+
+
+def test_missing_file(test_data_dir, tmpdir):
+    crate_dir = test_data_dir / 'read_crate'
+    name = 'test_file_galaxy.txt'
+    test_path = crate_dir / name
+    test_path.unlink()
+    crate = ROCrate(crate_dir)
+
+    test_file = crate.dereference(name)
+    assert test_file.id == name
+
+    out_path = tmpdir / 'crate_read_out'
+    crate.write_crate(out_path)
+    assert not (out_path / name).exists()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -174,13 +174,13 @@ def test_missing_source(test_data_dir, tmpdir, fetch_remote, validate_url):
     assert file_ is crate.dereference(path.name)
     out_path = tmpdir / 'ro_crate_out_1'
     crate.write_crate(out_path)
-    assert not(out_path / path.name).exists()
+    assert not (out_path / path.name).exists()
 
     crate = ROCrate()
     file_ = crate.add_file(str(path), path.name, **args)
     assert file_ is crate.dereference(path.name)
     out_path = tmpdir / 'ro_crate_out_2'
-    assert not(out_path / path.name).exists()
+    assert not (out_path / path.name).exists()
 
 
 @pytest.mark.parametrize("fetch_remote,validate_url", [(False, False), (False, True), (True, False), (True, True)])

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -165,14 +165,22 @@ def test_remote_uri_exceptions(tmpdir):
 
 
 @pytest.mark.parametrize("fetch_remote,validate_url", [(False, False), (False, True), (True, False), (True, True)])
-def test_missing_source(test_data_dir, fetch_remote, validate_url):
-    crate = ROCrate()
+def test_missing_source(test_data_dir, tmpdir, fetch_remote, validate_url):
     path = test_data_dir / uuid.uuid4().hex
-    with pytest.raises(ValueError):
-        crate.add_file(str(path), fetch_remote=fetch_remote, validate_url=validate_url)
+    args = {"fetch_remote": fetch_remote, "validate_url": validate_url}
 
-    with pytest.raises(ValueError):
-        crate.add_file(str(path), path.name, fetch_remote=fetch_remote, validate_url=validate_url)
+    crate = ROCrate()
+    file_ = crate.add_file(str(path), **args)
+    assert file_ is crate.dereference(path.name)
+    out_path = tmpdir / 'ro_crate_out_1'
+    crate.write_crate(out_path)
+    assert not(out_path / path.name).exists()
+
+    crate = ROCrate()
+    file_ = crate.add_file(str(path), path.name, **args)
+    assert file_ is crate.dereference(path.name)
+    out_path = tmpdir / 'ro_crate_out_2'
+    assert not(out_path / path.name).exists()
 
 
 @pytest.mark.parametrize("fetch_remote,validate_url", [(False, False), (False, True), (True, False), (True, True)])


### PR DESCRIPTION
Closes #73.

With this PR, the library does not complain if files and directories referenced by the RO-Crate metadata are missing. Corresponding entities are created as usual and the crate can be written out, but missing files will of course also be missing from the output crate.