### PR TITLE
Avoid duplicate copies when writing out the crate

### DIFF
--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -19,7 +19,6 @@
 
 import os
 from pathlib import Path
-import shutil
 
 from .data_entity import DataEntity
 
@@ -46,27 +45,8 @@ class Dataset(DataEntity):
     def format_id(self, identifier):
         return identifier.rstrip("/") + "/"
 
-    def directory_entries(self, base_path=None):
-        # iterate over the source dir contents to list all entries
-        directory_entries = []
-        if self.source and os.path.exists(self.source):
-            for base, subd, filenames in os.walk(self.source):
-                for filename in filenames:
-                    file_source = os.path.join(base, filename)
-                    rel_path = os.path.relpath(file_source, self.source)
-                    if base_path:
-                        dest_path = os.path.join(base_path, rel_path)
-                    else:
-                        dest_path = rel_path
-                    file_entry = (file_source, dest_path)
-                    directory_entries.append(file_entry)
-        return directory_entries
-
     def write(self, base_path):
         out_path = self.filepath(base_path)
         Path(out_path).mkdir(parents=True, exist_ok=True)
-        for file_src, file_dest in self.directory_entries(out_path):
-            file_dest_path = os.path.dirname(file_dest)
-            if not os.path.exists(file_dest_path):
-                os.makedirs(file_dest_path)
-            shutil.copyfile(file_src, file_dest)
+        if not self.crate.source_path and self.source and os.path.exists(self.source):
+            self.crate._copy_unlisted(self.source, out_path)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -467,26 +467,26 @@ class ROCrate():
     # def fetch_all(self):
         # fetch all files defined in the crate
 
+    def _copy_unlisted(self, top, base_path):
+        for root, dirs, files in os.walk(top):
+            root = Path(root)
+            for name in dirs:
+                source = root / name
+                dest = base_path / source.relative_to(top)
+                dest.mkdir(parents=True, exist_ok=True)
+            for name in files:
+                source = root / name
+                rel = source.relative_to(top)
+                if not self.dereference(str(rel)):
+                    dest = base_path / rel
+                    shutil.copyfile(source, dest)
+
     # write crate to local dir
     def write_crate(self, base_path):
         base_path = Path(base_path)
         base_path.mkdir(parents=True, exist_ok=True)
-        # copy unlisted files and directories
         if self.source_path:
-            top = self.source_path
-            for root, dirs, files in os.walk(top):
-                root = Path(root)
-                for name in dirs:
-                    source = root / name
-                    dest = base_path / source.relative_to(top)
-                    dest.mkdir(parents=True, exist_ok=True)
-                for name in files:
-                    source = root / name
-                    rel = source.relative_to(top)
-                    if not self.dereference(str(rel)):
-                        dest = base_path / rel
-                        shutil.copyfile(source, dest)
-        # write data entities
+            self._copy_unlisted(self.source_path, base_path)
         for writable_entity in self.data_entities + self.default_entities:
             writable_entity.write(str(base_path))
 


### PR DESCRIPTION
Fixes #83.

Now `Dataset.write` only copies unlisted files and directories if there's no source path for the crate (i.e., if the crate was generated from scratch rather than read from a directory); if there's a source path, the `ROCrate` object takes care of that instead.