### PR TITLE
Entity: implementation as a mutable mapping

### DIFF
--- a/rocrate/model/computationalworkflow.py
+++ b/rocrate/model/computationalworkflow.py
@@ -42,7 +42,7 @@ class ComputationalWorkflow(File):
 
     @property
     def programmingLanguage(self):
-        return self["programmingLanguage"]
+        return self.get("programmingLanguage")
 
     @programmingLanguage.setter
     def programmingLanguage(self, programmingLanguage):
@@ -52,7 +52,7 @@ class ComputationalWorkflow(File):
 
     @property
     def subjectOf(self):
-        return self["subjectOf"]
+        return self.get("subjectOf")
 
     @subjectOf.setter
     def subjectOf(self, subjectOf):

--- a/rocrate/model/computerlanguage.py
+++ b/rocrate/model/computerlanguage.py
@@ -28,7 +28,7 @@ class ComputerLanguage(ContextEntity):
 
     @property
     def name(self):
-        return self["name"]
+        return self.get("name")
 
     @name.setter
     def name(self, name):
@@ -36,7 +36,7 @@ class ComputerLanguage(ContextEntity):
 
     @property
     def alternateName(self):
-        return self["alternateName"]
+        return self.get("alternateName")
 
     @alternateName.setter
     def alternateName(self, alternateName):
@@ -44,7 +44,7 @@ class ComputerLanguage(ContextEntity):
 
     @property
     def identifier(self):
-        return self["identifier"]
+        return self.get("identifier")
 
     @identifier.setter
     def identifier(self, identifier):
@@ -52,7 +52,7 @@ class ComputerLanguage(ContextEntity):
 
     @property
     def url(self):
-        return self["url"]
+        return self.get("url")
 
     @url.setter
     def url(self, url):
@@ -61,7 +61,7 @@ class ComputerLanguage(ContextEntity):
     # Not listed as a property in "https://schema.org/ComputerLanguage"
     @property
     def version(self):
-        return self["version"]
+        return self.get("version")
 
     @version.setter
     def version(self, version):

--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -18,12 +18,13 @@
 # limitations under the License.
 
 import uuid
+from collections.abc import MutableMapping
 
 from dateutil.parser import isoparse
 from .. import vocabs
 
 
-class Entity(object):
+class Entity(MutableMapping):
 
     def __init__(self, crate, identifier=None, properties=None):
         self.crate = crate
@@ -62,8 +63,8 @@ class Entity(object):
     def canonical_id(self):
         return self.crate.resolve_id(self.id)
 
-    def hash(self):
-        hash(self.canonical_id())
+    def __hash__(self):
+        return hash(self.canonical_id())
 
     def _empty(self):
         val = {
@@ -72,25 +73,52 @@ class Entity(object):
         }
         return val
 
-    def __getitem__(self, key: str):
-        v = self._jsonld.get(key)
-        if not v or isinstance(v, str) or key.startswith("@"):
+    def __getitem__(self, key):
+        v = self._jsonld[key]
+        if isinstance(v, str) or key.startswith("@"):
             return v
         values = v if isinstance(v, list) else [v]
         deref_values = [self.crate.dereference(_["@id"], _["@id"]) for _ in values]
         return deref_values if isinstance(v, list) else deref_values[0]
 
     def __setitem__(self, key: str, value):
+        if key.startswith("@"):
+            raise KeyError(f"cannot set '{key}'")
         values = value if isinstance(value, list) else [value]
         ref_values = [{"@id": _.id} if isinstance(_, Entity) else _ for _ in values]
         self._jsonld[key] = ref_values if isinstance(value, list) else ref_values[0]
 
     def __delitem__(self, key: str):
+        if key.startswith("@"):
+            raise KeyError(f"cannot delete '{key}'")
         del self._jsonld[key]
 
+    def popitem(self):
+        raise NotImplementedError
+
+    def clear(self):
+        raise NotImplementedError
+
+    def update(self):
+        raise NotImplementedError
+
+    def __iter__(self):
+        return iter(self._jsonld)
+
+    def __len__(self):
+        return len(self._jsonld)
+
+    def __contains__(self, key):
+        return key in self._jsonld
+
+    def __eq__(self, other):
+        if not isinstance(other, Entity):
+            return NotImplemented
+        return self.id == other.id and self._jsonld == other._jsonld
+
     @property
-    def type(self) -> str:
-        return self['@type']
+    def type(self):
+        return self._jsonld['@type']
 
     # @property
     # def types(self)-> List[str]:
@@ -98,7 +126,7 @@ class Entity(object):
 
     @property
     def datePublished(self):
-        d = self['datePublished']
+        d = self.get('datePublished')
         return d if not d else isoparse(d)
 
     @datePublished.setter

--- a/rocrate/model/softwareapplication.py
+++ b/rocrate/model/softwareapplication.py
@@ -29,7 +29,7 @@ class SoftwareApplication(ContextEntity, CreativeWork):
 
     @property
     def name(self):
-        return self["name"]
+        return self.get("name")
 
     @name.setter
     def name(self, name):
@@ -37,7 +37,7 @@ class SoftwareApplication(ContextEntity, CreativeWork):
 
     @property
     def url(self):
-        return self["url"]
+        return self.get("url")
 
     @url.setter
     def url(self, url):
@@ -45,7 +45,7 @@ class SoftwareApplication(ContextEntity, CreativeWork):
 
     @property
     def version(self):
-        return self["version"]
+        return self.get("version")
 
     @version.setter
     def version(self, version):

--- a/rocrate/model/testdefinition.py
+++ b/rocrate/model/testdefinition.py
@@ -32,7 +32,7 @@ class TestDefinition(File):
 
     @property
     def engineVersion(self):
-        return self["engineVersion"]
+        return self.get("engineVersion")
 
     @engineVersion.setter
     def engineVersion(self, engineVersion):
@@ -40,7 +40,7 @@ class TestDefinition(File):
 
     @property
     def conformsTo(self):
-        return self["conformsTo"]
+        return self.get("conformsTo")
 
     @conformsTo.setter
     def conformsTo(self, conformsTo):

--- a/rocrate/model/testinstance.py
+++ b/rocrate/model/testinstance.py
@@ -32,7 +32,7 @@ class TestInstance(ContextEntity):
 
     @property
     def name(self):
-        return self["name"]
+        return self.get("name")
 
     @name.setter
     def name(self, name):
@@ -40,7 +40,7 @@ class TestInstance(ContextEntity):
 
     @property
     def resource(self):
-        return self["resource"]
+        return self.get("resource")
 
     @resource.setter
     def resource(self, resource):
@@ -48,7 +48,7 @@ class TestInstance(ContextEntity):
 
     @property
     def runsOn(self):
-        return self["runsOn"]
+        return self.get("runsOn")
 
     @runsOn.setter
     def runsOn(self, runsOn):
@@ -56,7 +56,7 @@ class TestInstance(ContextEntity):
 
     @property
     def url(self):
-        return self["url"]
+        return self.get("url")
 
     @url.setter
     def url(self, url):

--- a/rocrate/model/testservice.py
+++ b/rocrate/model/testservice.py
@@ -32,7 +32,7 @@ class TestService(ContextEntity):
 
     @property
     def name(self):
-        return self["name"]
+        return self.get("name")
 
     @name.setter
     def name(self, name):
@@ -40,7 +40,7 @@ class TestService(ContextEntity):
 
     @property
     def url(self):
-        return self["url"]
+        return self.get("url")
 
     @url.setter
     def url(self, url):

--- a/rocrate/model/testsuite.py
+++ b/rocrate/model/testsuite.py
@@ -32,7 +32,7 @@ class TestSuite(ContextEntity):
 
     @property
     def name(self):
-        return self["name"]
+        return self.get("name")
 
     @name.setter
     def name(self, name):
@@ -40,7 +40,7 @@ class TestSuite(ContextEntity):
 
     @property
     def instance(self):
-        return self["instance"]
+        return self.get("instance")
 
     @instance.setter
     def instance(self, instance):
@@ -48,7 +48,7 @@ class TestSuite(ContextEntity):
 
     @property
     def definition(self):
-        return self["definition"]
+        return self.get("definition")
 
     @definition.setter
     def definition(self, definition):

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -219,7 +219,7 @@ class ROCrate():
 
     @property
     def name(self):
-        return self.root_dataset['name']
+        return self.root_dataset.get('name')
 
     @name.setter
     def name(self, value):
@@ -235,7 +235,7 @@ class ROCrate():
 
     @property
     def creator(self):
-        return self.root_dataset['creator']
+        return self.root_dataset.get('creator')
 
     @creator.setter
     def creator(self, value):
@@ -243,7 +243,7 @@ class ROCrate():
 
     @property
     def license(self):
-        return self.root_dataset['license']
+        return self.root_dataset.get('license')
 
     @license.setter
     def license(self, value):
@@ -251,7 +251,7 @@ class ROCrate():
 
     @property
     def description(self):
-        return self.root_dataset['description']
+        return self.root_dataset.get('description')
 
     @description.setter
     def description(self, value):
@@ -259,7 +259,7 @@ class ROCrate():
 
     @property
     def keywords(self):
-        return self.root_dataset['keywords']
+        return self.root_dataset.get('keywords')
 
     @keywords.setter
     def keywords(self, value):
@@ -267,7 +267,7 @@ class ROCrate():
 
     @property
     def publisher(self):
-        return self.root_dataset['publisher']
+        return self.root_dataset.get('publisher')
 
     @publisher.setter
     def publisher(self, value):
@@ -275,7 +275,7 @@ class ROCrate():
 
     @property
     def isBasedOn(self):
-        return self.root_dataset['isBasedOn']
+        return self.root_dataset.get('isBasedOn')
 
     @isBasedOn.setter
     def isBasedOn(self, value):
@@ -283,7 +283,7 @@ class ROCrate():
 
     @property
     def image(self):
-        return self.root_dataset['image']
+        return self.root_dataset.get('image')
 
     @image.setter
     def image(self, value):
@@ -291,7 +291,7 @@ class ROCrate():
 
     @property
     def CreativeWorkStatus(self):
-        return self.root_dataset['CreativeWorkStatus']
+        return self.root_dataset.get('CreativeWorkStatus')
 
     @CreativeWorkStatus.setter
     def CreativeWorkStatus(self, value):
@@ -299,7 +299,7 @@ class ROCrate():
 
     @property
     def mainEntity(self):
-        return self.root_dataset['mainEntity']
+        return self.root_dataset.get('mainEntity')
 
     @mainEntity.setter
     def mainEntity(self, value):
@@ -321,10 +321,10 @@ class ROCrate():
 
     @property
     def test_suites(self):
-        mentions = [_ for _ in (self.root_dataset['mentions'] or []) if isinstance(_, TestSuite)]
-        about = [_ for _ in (self.root_dataset['about'] or []) if isinstance(_, TestSuite)]
+        mentions = [_ for _ in self.root_dataset.get('mentions', []) if isinstance(_, TestSuite)]
+        about = [_ for _ in self.root_dataset.get('about', []) if isinstance(_, TestSuite)]
         if self.test_dir:
-            legacy_about = [_ for _ in (self.test_dir['about'] or []) if isinstance(_, TestSuite)]
+            legacy_about = [_ for _ in self.test_dir.get('about', []) if isinstance(_, TestSuite)]
             about += legacy_about
         return list(set(mentions + about))  # remove any duplicate refs
 
@@ -439,7 +439,7 @@ class ROCrate():
                     self.data_entities.remove(e)
                 except ValueError:
                     pass
-                self.root_dataset["hasPart"] = [_ for _ in self.root_dataset["hasPart"] or [] if _ != e]
+                self.root_dataset["hasPart"] = [_ for _ in self.root_dataset.get("hasPart", []) if _ != e]
                 if not self.root_dataset["hasPart"]:
                     del self.root_dataset._jsonld["hasPart"]
             else:

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -339,9 +339,11 @@ class ROCrate():
     def _get_root_jsonld(self):
         self.root_dataset.properties()
 
-    def dereference(self, entity_id):
+    def dereference(self, entity_id, default=None):
         canonical_id = self.resolve_id(entity_id)
-        return self.__entity_map.get(canonical_id, None)
+        return self.__entity_map.get(canonical_id, default)
+
+    get = dereference
 
     def add_file(
             self,

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -32,8 +32,8 @@ def test_galaxy_wf_crate(test_data_dir, tmpdir, helpers):
     lang = wf_crate.dereference("#galaxy")
     assert hasattr(lang, "name")
     assert lang.version == GALAXY_DEFAULT_VERSION
-    assert wf["programmingLanguage"] is lang
-    assert wf["subjectOf"] is not None
+    assert wf.get("programmingLanguage") is lang
+    assert wf.get("subjectOf") is not None
     assert helpers.WORKFLOW_TYPES.issubset(wf["subjectOf"].type)
 
     out_path = tmpdir / 'ro_crate_out'
@@ -67,8 +67,8 @@ def test_cwl_wf_crate(test_data_dir, tmpdir, helpers):
     lang = wf_crate.dereference("#cwl")
     assert hasattr(lang, "name")
     assert lang.version == CWL_DEFAULT_VERSION
-    assert wf["programmingLanguage"] is lang
-    assert wf["subjectOf"] is None
+    assert wf.get("programmingLanguage") is lang
+    assert "subjectOf" not in wf
 
     out_path = tmpdir / 'ro_crate_out'
     out_path.mkdir()
@@ -98,8 +98,8 @@ def test_create_wf_include(test_data_dir, tmpdir, helpers):
     lang = wf_crate.dereference("#galaxy")
     assert hasattr(lang, "name")
     assert lang.version == GALAXY_DEFAULT_VERSION
-    assert wf["programmingLanguage"] is lang
-    assert wf["subjectOf"] is not None
+    assert wf.get("programmingLanguage") is lang
+    assert wf.get("subjectOf") is not None
     assert helpers.WORKFLOW_TYPES.issubset(wf["subjectOf"].type)
     assert wf_crate.dereference(extra_file1.name) is not None
     assert wf_crate.dereference(extra_file2.name) is not None

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import datetime
+import json
 import tempfile
 import uuid
 from pathlib import Path
@@ -177,7 +178,7 @@ def test_uuid():
 
 def test_update(test_data_dir, tmpdir, helpers):
     crate = ROCrate()
-    assert not crate.root_dataset["hasPart"]
+    assert "hasPart" not in crate.root_dataset
     wf_path = test_data_dir / "test_galaxy_wf.ga"
     john = crate.add(Person(crate, '#john', {'name': 'John Doe'}))
     file_ = crate.add_file(wf_path)
@@ -187,7 +188,7 @@ def test_update(test_data_dir, tmpdir, helpers):
     assert crate.mainEntity is None
     wf = crate.add_workflow(wf_path, main=True, lang="galaxy")
     assert isinstance(wf, ComputationalWorkflow)
-    assert wf["author"] is None
+    assert "author" not in wf
     assert crate.mainEntity is wf
     assert crate.dereference(john.id) is john
     assert crate.dereference(file_.id) is wf
@@ -225,7 +226,7 @@ def test_delete(test_data_dir):
     assert file1 not in crate.root_dataset["hasPart"]
     crate.delete(file2)
     assert file2 not in crate.data_entities
-    assert crate.root_dataset["hasPart"] is None
+    assert "hasPart" not in crate.root_dataset
     crate.delete(file2)  # no-op
     # contextual entities
     john = crate.add(Person(crate, '#john', {'name': 'John Doe'}))
@@ -266,7 +267,7 @@ def test_delete_by_id(test_data_dir):
     assert f.id == path.name
     crate.delete(path.name)
     assert f not in crate.data_entities
-    assert crate.root_dataset["hasPart"] is None
+    assert "hasPart" not in crate.root_dataset
 
 
 def test_self_delete(test_data_dir):
@@ -277,4 +278,56 @@ def test_self_delete(test_data_dir):
     assert f in crate.root_dataset["hasPart"]
     f.delete()
     assert f not in crate.data_entities
-    assert crate.root_dataset["hasPart"] is None
+    assert "hasPart" not in crate.root_dataset
+
+
+def test_entity_as_mapping(tmpdir, helpers):
+    orcid = "https://orcid.org/0000-0002-1825-0097"
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {"@id": "ro-crate-metadata.json",
+             "@type": "CreativeWork",
+             "about": {"@id": "./"},
+             "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"}},
+            {"@id": "./",
+             "@type": "Dataset",
+             "author": {"@id": orcid}},
+            {"@id": orcid,
+             "@type": "Person",
+             "givenName": "Josiah",
+             "familyName": "Carberry"}
+        ]
+    }
+    crate_dir = tmpdir / "in_crate"
+    crate_dir.mkdir()
+    with open(crate_dir / helpers.METADATA_FILE_NAME, "wt") as f:
+        json.dump(metadata, f, indent=4)
+    crate = ROCrate(crate_dir)
+    person = crate.dereference(orcid)
+    assert len(person) == 4
+    assert len(list(person)) == 4
+    assert set(person) == set(person.keys()) == {"@id", "@type", "givenName", "familyName"}
+    assert set(person.values()) == {orcid, "Person", "Josiah", "Carberry"}
+    assert set(person.items()) == set(zip(person.keys(), person.values()))
+    assert person.setdefault("givenName", "foo") == "Josiah"
+    assert len(person) == 4
+    assert person.setdefault("award", "Oscar") == "Oscar"
+    assert len(person) == 5
+    assert "award" in person
+    assert person.pop("award") == "Oscar"
+    assert len(person) == 4
+    assert "award" not in person
+    for key in "@id", "@type":
+        with pytest.raises(KeyError):
+            person[key] = "foo"
+        with pytest.raises(KeyError):
+            del person[key]
+        with pytest.raises(KeyError):
+            person.pop(key)
+    twin = Person(crate, orcid, properties={
+        "givenName": "Josiah",
+        "familyName": "Carberry"
+    })
+    assert twin == person
+    assert Person(crate, orcid) != person

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -54,6 +54,13 @@ def test_dereferencing(test_data_dir, helpers):
     readme_entity = crate.add_file(readme_url)
     assert crate.dereference(readme_url) is readme_entity
 
+    # dereference nonexistent entity
+    assert crate.dereference(f"#{uuid.uuid4()}") is None
+    assert crate.dereference(f"#{uuid.uuid4()}", file_returned) is file_returned
+
+    # alias
+    assert crate.get(readme_url) is readme_entity
+
 
 @pytest.mark.parametrize("name", [".foo", "foo.", ".foo/", "foo./"])
 def test_dereferencing_equivalent_id(test_data_dir, name):

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -245,7 +245,7 @@ def test_no_parts(tmpdir):
     crate.write(out_path)
 
     crate = ROCrate(out_path)
-    assert not crate.root_dataset["hasPart"]
+    assert "hasPart" not in crate.root_dataset
 
 
 @pytest.mark.parametrize("to_zip", [False, True])


### PR DESCRIPTION
Fixes #81.

`Entity` now behaves like a [MutableMapping](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping) (e.g., a dictionary), with special behavior for keys that start with `"@"` (mainly so that the entity's id and type cannot be altered).

**Note:**

A lot of PRs so far introduced breaking changes, and that is fine since we are still at [major version 0](https://semver.org/#spec-item-4). However, one of the changes made here in order to make `Entity` behave like a proper mapping type should be carefully noted:

`Entity.__getitem__` now raises a `KeyError` if the key is not in the json-ld dict:

```python
p = crate.add(Person(crate, "Joe"))
p["foobar"]  # KeyError
```

Previously, it returned `None`. Now this behavior can be obtained by calling `get`, as for regular dictionaries.

```python
p.get("foobar")  # returns None
```

