### PR TITLE
Notebook on mapping schema.org to the ro-crate-py model

### DIFF
--- a/notebooks/ExploreSchemaOrg.ipynb
+++ b/notebooks/ExploreSchemaOrg.ipynb
@@ -473,7 +473,7 @@
     {
      "data": {
       "text/plain": [
-       "'http://schema.org/EUEnergyEfficiencyEnumeration'"
+       "'http://schema.org/GenderType'"
       ]
      },
      "execution_count": 16,
@@ -712,7 +712,7 @@
     {
      "data": {
       "text/plain": [
-       "'http://schema.org/StudioAlbum'"
+       "'http://schema.org/Osteopathic'"
       ]
      },
      "execution_count": 24,
@@ -868,6 +868,283 @@
    ],
    "source": [
     "set.union(*(set(type_map[_][\"rdfs:subClassOf\"]) for _ in enum_values_with_superclass))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mapping the schema.org type hierarchy to Python classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can map enums to Python [enums](https://docs.python.org/3.6/library/enum.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from enum import Enum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Enum` can be considered as the mapping for `Enumeration`. All other enumerations can be mapped to Enum subclasses. Note that only leaf enumerations have values, while superclasses must have no members. We already know the `Enumeration -> MedicalEnumeration -> PhysicalExam` hierarchy: let's try to map it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Abdomen',\n",
+       " 'Appearance',\n",
+       " 'CardiovascularExam',\n",
+       " 'Ear',\n",
+       " 'Eye',\n",
+       " 'Genitourinary',\n",
+       " 'Head',\n",
+       " 'Lung',\n",
+       " 'MusculoskeletalExam',\n",
+       " 'Neck',\n",
+       " 'Neuro',\n",
+       " 'Nose',\n",
+       " 'Skin',\n",
+       " 'Throat']"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "physical_exam_values = sorted(\n",
+    "    _.rsplit(\"/\", 1)[-1] for _ in enum_values\n",
+    "    if \"http://schema.org/PhysicalExam\" in type_map[_][\"@type\"]\n",
+    ")\n",
+    "physical_exam_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class MedicalEnumeration(Enum):\n",
+    "    pass\n",
+    "\n",
+    "PhysicalExam = MedicalEnumeration(\"PhysicalExam\", physical_exam_values)\n",
+    "e = PhysicalExam.Neck\n",
+    "e == PhysicalExam.Ear"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "isinstance(e, MedicalEnumeration)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With respect to the current ro-crate-py model, in principle, these types could avoid being derived from `Entity`, but then the logic for adding and manipulating entites must take into account this different kind of entity.\n",
+    "\n",
+    "What about \"regular\" (non-enum) types? We can have `Thing` map to our `Entity`, then it's only a matter of deriving other classes as required. Or is it?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'http://schema.org/3DModel'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "regular_types = set(_[\"@id\"] for _ in types) - enums\n",
+    "superclasses = set.union(*[set(type_map[_].get(\"rdfs:subClassOf\", [])) for _ in regular_types])\n",
+    "leaves = regular_types - superclasses\n",
+    "sorted(leaves)[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's our first problem: `3DModel` is not a valid Python identifier since it starts with a digit. Let's ignore this for now and pick another one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'http://schema.org/Zoo'"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(leaves)[-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'@id': 'http://schema.org/CivicStructure',\n",
+       "  '@type': ['rdfs:Class'],\n",
+       "  'rdfs:comment': 'A public structure, such as a town hall or concert hall.',\n",
+       "  'rdfs:label': 'CivicStructure',\n",
+       "  'rdfs:subClassOf': ['http://schema.org/Place']}]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def parents(t):\n",
+    "    return [type_map[_] for _ in type_map[t][\"rdfs:subClassOf\"]]\n",
+    "parents('http://schema.org/Zoo')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'@id': 'http://schema.org/Place',\n",
+       "  '@type': ['rdfs:Class'],\n",
+       "  'rdfs:comment': 'Entities that have a somewhat fixed, physical extension.',\n",
+       "  'rdfs:label': 'Place',\n",
+       "  'rdfs:subClassOf': ['http://schema.org/Thing']}]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parents('http://schema.org/CivicStructure')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'@id': 'http://schema.org/Thing',\n",
+       "  '@type': ['rdfs:Class'],\n",
+       "  'rdfs:comment': 'The most generic type of item.',\n",
+       "  'rdfs:label': 'Thing'}]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parents('http://schema.org/Place')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the general case there might be multiple inheritance. Also, of course the above naive code is not the most efficient way of generating the whole class hierarchy. In this case, though, the structure could be:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Entity:  # in the real case this would be the ro-crate-py Entity class\n",
+    "    pass\n",
+    "\n",
+    "class Place(Entity):\n",
+    "    pass\n",
+    "\n",
+    "class CivicStructure(Place):\n",
+    "    pass\n",
+    "\n",
+    "class Zoo(CivicStructure):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, we currently have a `ContextEntity, DataEntity` level below `Entity`. Most entities in schema.org could probably be derived from `ContextEntity`, but some are data entities. Also, custom RO-Crate aliases must be taken into account: for instance, `File` is an RO-Crate alias for http://schema.org/MediaObject, a subclass of http://schema.org/CreativeWork. Incidentally, `CreativeWork` is already present in our current model, but it's a direct subclass of `Entity`."
    ]
   }
  ],

--- a/notebooks/ExploreSchemaOrg.ipynb
+++ b/notebooks/ExploreSchemaOrg.ipynb
@@ -1,0 +1,895 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook explores the structure of [Schema.org](http://schema.org/) types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2588"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(\"../rocrate/data/schema.jsonld\") as f:\n",
+    "    schema = json.load(f)\n",
+    "entities = schema[\"@graph\"]\n",
+    "len(entities)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/SteeringPositionValue',\n",
+       " '@type': 'rdfs:Class',\n",
+       " 'http://schema.org/source': {'@id': 'http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group'},\n",
+       " 'rdfs:comment': 'A value indicating a steering position.',\n",
+       " 'rdfs:label': 'SteeringPositionValue',\n",
+       " 'rdfs:subClassOf': {'@id': 'http://schema.org/QualitativeValue'}}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "entities[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Normalize: ensure that the value of `\"@type\"` and `\"rdfs:subClassOf\"` is always a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for e in entities:\n",
+    "    types = e.get(\"@type\", [])\n",
+    "    if isinstance(types, str):\n",
+    "        e[\"@type\"] = [types]\n",
+    "    subclasses = e.get(\"rdfs:subClassOf\", [])\n",
+    "    if isinstance(subclasses, dict):\n",
+    "        e[\"rdfs:subClassOf\"] = [subclasses]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Flatten `\"rdfs:subClassOf\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for e in entities:\n",
+    "    try:\n",
+    "        subclasses = e[\"rdfs:subClassOf\"]\n",
+    "    except KeyError:\n",
+    "        pass\n",
+    "    else:\n",
+    "        e[\"rdfs:subClassOf\"] = [_[\"@id\"] for _ in subclasses]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/SteeringPositionValue',\n",
+       " '@type': ['rdfs:Class'],\n",
+       " 'http://schema.org/source': {'@id': 'http://www.w3.org/wiki/WebSchemas/SchemaDotOrgSources#Automotive_Ontology_Working_Group'},\n",
+       " 'rdfs:comment': 'A value indicating a steering position.',\n",
+       " 'rdfs:label': 'SteeringPositionValue',\n",
+       " 'rdfs:subClassOf': ['http://schema.org/QualitativeValue']}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "entities[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Schema.org entities have one or more types. Since (some) entities are the actual types we are looking for, we'll call their types \"metatypes\". Is `rdfs:Class` the only metatype?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'http://schema.org/ActionStatusType',\n",
+       " 'http://schema.org/BoardingPolicyType',\n",
+       " 'http://schema.org/BookFormatType',\n",
+       " 'http://schema.org/Boolean',\n",
+       " 'http://schema.org/CarUsageType',\n",
+       " 'http://schema.org/ContactPointOption',\n",
+       " 'http://schema.org/DataType',\n",
+       " 'http://schema.org/DayOfWeek',\n",
+       " 'http://schema.org/DeliveryMethod',\n",
+       " 'http://schema.org/DigitalDocumentPermissionType',\n",
+       " 'http://schema.org/DriveWheelConfigurationValue',\n",
+       " 'http://schema.org/DrugCostCategory',\n",
+       " 'http://schema.org/DrugPregnancyCategory',\n",
+       " 'http://schema.org/DrugPrescriptionStatus',\n",
+       " 'http://schema.org/EUEnergyEfficiencyEnumeration',\n",
+       " 'http://schema.org/EnergyStarEnergyEfficiencyEnumeration',\n",
+       " 'http://schema.org/EventAttendanceModeEnumeration',\n",
+       " 'http://schema.org/EventStatusType',\n",
+       " 'http://schema.org/GamePlayMode',\n",
+       " 'http://schema.org/GameServerStatus',\n",
+       " 'http://schema.org/GenderType',\n",
+       " 'http://schema.org/GovernmentBenefitsType',\n",
+       " 'http://schema.org/HealthAspectEnumeration',\n",
+       " 'http://schema.org/InfectiousAgentClass',\n",
+       " 'http://schema.org/ItemAvailability',\n",
+       " 'http://schema.org/ItemListOrderType',\n",
+       " 'http://schema.org/LegalForceStatus',\n",
+       " 'http://schema.org/LegalValueLevel',\n",
+       " 'http://schema.org/MapCategoryType',\n",
+       " 'http://schema.org/MediaManipulationRatingEnumeration',\n",
+       " 'http://schema.org/MedicalAudienceType',\n",
+       " 'http://schema.org/MedicalDevicePurpose',\n",
+       " 'http://schema.org/MedicalEvidenceLevel',\n",
+       " 'http://schema.org/MedicalImagingTechnique',\n",
+       " 'http://schema.org/MedicalObservationalStudyDesign',\n",
+       " 'http://schema.org/MedicalProcedureType',\n",
+       " 'http://schema.org/MedicalSpecialty',\n",
+       " 'http://schema.org/MedicalStudyStatus',\n",
+       " 'http://schema.org/MedicalTrialDesign',\n",
+       " 'http://schema.org/MedicineSystem',\n",
+       " 'http://schema.org/MerchantReturnEnumeration',\n",
+       " 'http://schema.org/MusicAlbumProductionType',\n",
+       " 'http://schema.org/MusicAlbumReleaseType',\n",
+       " 'http://schema.org/MusicReleaseFormatType',\n",
+       " 'http://schema.org/NLNonprofitType',\n",
+       " 'http://schema.org/OfferItemCondition',\n",
+       " 'http://schema.org/OrderStatus',\n",
+       " 'http://schema.org/PaymentStatusType',\n",
+       " 'http://schema.org/PhysicalActivityCategory',\n",
+       " 'http://schema.org/PhysicalExam',\n",
+       " 'http://schema.org/ProductReturnEnumeration',\n",
+       " 'http://schema.org/RefundTypeEnumeration',\n",
+       " 'http://schema.org/ReservationStatusType',\n",
+       " 'http://schema.org/RestrictedDiet',\n",
+       " 'http://schema.org/ReturnFeesEnumeration',\n",
+       " 'http://schema.org/RsvpResponseType',\n",
+       " 'http://schema.org/SteeringPositionValue',\n",
+       " 'http://schema.org/UKNonprofitType',\n",
+       " 'http://schema.org/USNonprofitType',\n",
+       " 'rdf:Property',\n",
+       " 'rdfs:Class'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "metatypes = set.union(*(set(e[\"@type\"]) for e in entities))\n",
+    "metatypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There's also `rdf:Property` and several other entities we'll explore later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are interested in the root(s) of the type hierarchy. Which types have no superclass? Probably properties: not because they're root types, but because they're not types at all. Let's check this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for e in entities:\n",
+    "    if \"rdf:Property\" in e[\"@type\"]:\n",
+    "        assert \"rdfs:subClassOf\" not in e"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's filter out properties then:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1214"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "types = [e for e in entities if \"rdf:Property\" not in e[\"@type\"]]\n",
+    "len(types)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which types have no superclass?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "344"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "no_superclass = [e for e in types if \"rdfs:subClassOf\" not in e]\n",
+    "len(no_superclass)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Are all these root types?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/Neck',\n",
+       " '@type': ['http://schema.org/PhysicalExam'],\n",
+       " 'http://schema.org/isPartOf': {'@id': 'http://health-lifesci.schema.org'},\n",
+       " 'rdfs:comment': 'Neck assessment with clinical examination.',\n",
+       " 'rdfs:label': 'Neck'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "no_superclass[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is not an `rdfs:Class`, but a `PhysicalExam`. That's one of the \"other\" metatypes seen above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/PhysicalExam',\n",
+       " '@type': ['rdfs:Class'],\n",
+       " 'http://schema.org/isPartOf': {'@id': 'http://health-lifesci.schema.org'},\n",
+       " 'rdfs:comment': 'A type of physical examination of a patient performed by a physician.',\n",
+       " 'rdfs:label': 'PhysicalExam',\n",
+       " 'rdfs:subClassOf': ['http://schema.org/MedicalEnumeration',\n",
+       "  'http://schema.org/MedicalProcedure']}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type_map = {e[\"@id\"]: e for e in types}\n",
+    "type_map['http://schema.org/PhysicalExam']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`PhysicalExam` is a subclass of `MedicalEnumeration` (and of `MedicalProcedure`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/MedicalEnumeration',\n",
+       " '@type': ['rdfs:Class'],\n",
+       " 'http://schema.org/isPartOf': {'@id': 'http://health-lifesci.schema.org'},\n",
+       " 'rdfs:comment': 'Enumerations related to health and the practice of medicine: A concept that is used to attribute a quality to another concept, as a qualifier, a collection of items or a listing of all of the elements of a set in medicine practice.',\n",
+       " 'rdfs:label': 'MedicalEnumeration',\n",
+       " 'rdfs:subClassOf': ['http://schema.org/Enumeration']}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type_map['http://schema.org/MedicalEnumeration']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`MedicalEnumeration` is, in turn, a subclass of `Enumeration`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/Enumeration',\n",
+       " '@type': ['rdfs:Class'],\n",
+       " 'rdfs:comment': 'Lists or enumerations—for example, a list of cuisines or music genres, etc.',\n",
+       " 'rdfs:label': 'Enumeration',\n",
+       " 'rdfs:subClassOf': ['http://schema.org/Intangible']}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enumeration = type_map['http://schema.org/Enumeration']\n",
+    "enumeration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thus, `Neck` is one of the possible values for the `PhysicalExam` enum. Let's get all enums (descendants of `Enumeration`) recursively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "70"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def r_enumerations(pid='http://schema.org/Enumeration'):\n",
+    "    for e in types:\n",
+    "        if pid in e.get('rdfs:subClassOf', []):\n",
+    "            yield e\n",
+    "            for se in r_enumerations(e[\"@id\"]):\n",
+    "                yield se\n",
+    "enums = set(_[\"@id\"] for _ in r_enumerations())\n",
+    "len(enums)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'http://schema.org/EUEnergyEfficiencyEnumeration'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next(iter(enums))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what's left if we filter out these from the metatypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'http://schema.org/Boolean',\n",
+       " 'http://schema.org/DataType',\n",
+       " 'rdf:Property',\n",
+       " 'rdfs:Class'}"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "metatypes.difference(enums)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'@id': 'http://schema.org/DataType',\n",
+       " '@type': ['rdfs:Class'],\n",
+       " 'rdfs:comment': 'The basic data types such as Integers, Strings, etc.',\n",
+       " 'rdfs:label': 'DataType',\n",
+       " 'rdfs:subClassOf': ['rdfs:Class']}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type_map[\"http://schema.org/DataType\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`DataType` is both an instance and a subclass of `rdfs:Class` (both a type and a metatype)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'@id': 'http://schema.org/DataType',\n",
+       "  '@type': ['rdfs:Class'],\n",
+       "  'rdfs:comment': 'The basic data types such as Integers, Strings, etc.',\n",
+       "  'rdfs:label': 'DataType',\n",
+       "  'rdfs:subClassOf': ['rdfs:Class']}]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[_ for _ in types if \"rdfs:Class\" in _.get(\"rdfs:subClassOf\", [])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So `DataType` is the only type that's a subclass of `rdfs:Class`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'@id': 'http://schema.org/Text',\n",
+       "  '@type': ['rdfs:Class', 'http://schema.org/DataType'],\n",
+       "  'rdfs:comment': 'Data type: Text.',\n",
+       "  'rdfs:label': 'Text'},\n",
+       " {'@id': 'http://schema.org/Number',\n",
+       "  '@type': ['http://schema.org/DataType', 'rdfs:Class'],\n",
+       "  'rdfs:comment': \"Data type: Number.<br/><br/>\\n\\nUsage guidelines:<br/><br/>\\n\\n<ul>\\n<li>Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.</li>\\n<li>Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.</li>\\n</ul>\\n\",\n",
+       "  'rdfs:label': 'Number'},\n",
+       " {'@id': 'http://schema.org/Time',\n",
+       "  '@type': ['http://schema.org/DataType', 'rdfs:Class'],\n",
+       "  'rdfs:comment': 'A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see <a href=\"http://www.w3.org/TR/xmlschema-2/#time\">XML schema for details</a>).',\n",
+       "  'rdfs:label': 'Time'},\n",
+       " {'@id': 'http://schema.org/Date',\n",
+       "  '@type': ['http://schema.org/DataType', 'rdfs:Class'],\n",
+       "  'rdfs:comment': 'A date value in <a href=\"http://en.wikipedia.org/wiki/ISO_8601\">ISO 8601 date format</a>.',\n",
+       "  'rdfs:label': 'Date'},\n",
+       " {'@id': 'http://schema.org/DateTime',\n",
+       "  '@type': ['rdfs:Class', 'http://schema.org/DataType'],\n",
+       "  'rdfs:comment': 'A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601).',\n",
+       "  'rdfs:label': 'DateTime'},\n",
+       " {'@id': 'http://schema.org/Boolean',\n",
+       "  '@type': ['http://schema.org/DataType', 'rdfs:Class'],\n",
+       "  'rdfs:comment': 'Boolean: True or False.',\n",
+       "  'rdfs:label': 'Boolean'}]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datatype_values = [_ for _ in types if \"http://schema.org/DataType\" in _[\"@type\"]]\n",
+    "datatype_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So `DataType` is effectively also an enum, with six possible values. What about `Boolean`?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'@id': 'http://schema.org/True',\n",
+       "  '@type': ['http://schema.org/Boolean'],\n",
+       "  'rdfs:comment': 'The boolean value true.',\n",
+       "  'rdfs:label': 'True'},\n",
+       " {'@id': 'http://schema.org/False',\n",
+       "  '@type': ['http://schema.org/Boolean'],\n",
+       "  'rdfs:comment': 'The boolean value false.',\n",
+       "  'rdfs:label': 'False'}]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "boolean_values = [_ for _ in types if \"http://schema.org/Boolean\" in _[\"@type\"]]\n",
+    "boolean_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also an enum, and a subclass of the `DataType` enum. To summarize, metatypes are either `rdf:Property`, `rdfs:Class` or enums."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for t in \"DataType\", \"Boolean\":\n",
+    "    enums.add(f\"https://schema.org/{t}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some enum values like `Neck` or `False` have no superclass, so they are part of the candidate root types set we've built above. Let's build a set of all enum values and subtract it from the candidate root types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "355"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enum_values = set()\n",
+    "for entity in types:\n",
+    "    if set(entity[\"@type\"]) <= enums:\n",
+    "        enum_values.add(entity[\"@id\"])\n",
+    "len(enum_values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'http://schema.org/StudioAlbum'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "next(iter(enum_values))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add values from the \"special\" `DataType` and `Boolean` enums."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enum_values |= set(_[\"@id\"] for _ in datatype_values)\n",
+    "enum_values |= {\"http://schema.org/False\", \"http://schema.org/True\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Back to the types with no superclass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'http://schema.org/Thing'}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "no_superclass_ids = set(_[\"@id\"] for _ in no_superclass)\n",
+    "no_superclass_ids - enum_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So the only \"real\" root type is `Thing`. All other types that don't have a superclass are enum values. However, some enum values have a superclass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'http://schema.org/CommunityHealth',\n",
+       " 'http://schema.org/Dermatology',\n",
+       " 'http://schema.org/DietNutrition',\n",
+       " 'http://schema.org/Emergency',\n",
+       " 'http://schema.org/Geriatric',\n",
+       " 'http://schema.org/Gynecologic',\n",
+       " 'http://schema.org/Midwifery',\n",
+       " 'http://schema.org/Nursing',\n",
+       " 'http://schema.org/Obstetric',\n",
+       " 'http://schema.org/Oncologic',\n",
+       " 'http://schema.org/Optometric',\n",
+       " 'http://schema.org/Otolaryngologic',\n",
+       " 'http://schema.org/Pediatric',\n",
+       " 'http://schema.org/Physiotherapy',\n",
+       " 'http://schema.org/PlasticSurgery',\n",
+       " 'http://schema.org/Podiatric',\n",
+       " 'http://schema.org/PrimaryCare',\n",
+       " 'http://schema.org/Psychiatric',\n",
+       " 'http://schema.org/PublicHealth',\n",
+       " 'http://schema.org/RespiratoryTherapy'}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enum_values_with_superclass = enum_values - no_superclass_ids\n",
+    "enum_values_with_superclass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These are the values of which enum?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'http://schema.org/MedicalSpecialty'}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set.union(*(set(type_map[_][\"@type\"]) for _ in enum_values_with_superclass))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And what are their superclasses?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'http://schema.org/MedicalBusiness', 'http://schema.org/MedicalTherapy'}"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set.union(*(set(type_map[_][\"rdfs:subClassOf\"]) for _ in enum_values_with_superclass))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Adds a Jupyter notebook that explores the schema.org type structure, including some considerations on integrating it into our model. Note that there's no discussion (for now, at least) of how we might actually do that in practice (by hand, via code generation, with metaclasses, ...), just some general considerations on how it would / should be structured and related issues.
