### PR TITLE
Fix handling of non-HTTP(S) URIs

### DIFF
--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 import shutil
 import urllib.request
+from http.client import HTTPResponse
 from io import BytesIO, StringIO
 
 from .file_or_dir import FileOrDir
@@ -46,16 +47,16 @@ class File(FileOrDir):
         elif is_url(str(self.source)) and (self.fetch_remote or self.validate_url):
             with urllib.request.urlopen(self.source) as response:
                 if self.validate_url:
-                    self._jsonld.update({
-                        'contentSize': response.getheader('Content-Length'),
-                        'encodingFormat': response.getheader('Content-Type')
-                    })
+                    if isinstance(response, HTTPResponse):
+                        self._jsonld.update({
+                            'contentSize': response.getheader('Content-Length'),
+                            'encodingFormat': response.getheader('Content-Type')
+                        })
                     if not self.fetch_remote:
                         self._jsonld['sdDatePublished'] = iso_now()
                 if self.fetch_remote:
                     out_file_path.parent.mkdir(parents=True, exist_ok=True)
-                    with open(out_file_path, 'wb') as out_file:
-                        shutil.copyfileobj(response, out_file)
+                    urllib.request.urlretrieve(response.url, out_file_path)
         elif os.path.isfile(self.source):
             out_file_path.parent.mkdir(parents=True, exist_ok=True)
             if not out_file_path.exists() or not out_file_path.samefile(self.source):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [flake8]
 ignore = E226,E741,E402,E129,W503,W504
 max-line-length = 127
+
+[tool:pytest]
+markers =
+    slow: marks tests as slow

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -159,6 +159,27 @@ def test_remote_uri(tmpdir, helpers, fetch_remote, validate_url, to_zip):
             assert "sdDatePublished" in props
 
 
+@pytest.mark.slow
+@pytest.mark.parametrize("fetch_remote", [False, True])
+def test_ftp_uri(tmpdir, fetch_remote):
+    crate = ROCrate()
+    url = 'ftp://ftp-trace.ncbi.nih.gov/pub/gdp/README'
+    relpath = "a/b/README"
+    if fetch_remote:
+        file_ = crate.add_file(url, relpath, fetch_remote=True)
+        assert file_.id == relpath
+    else:
+        file_ = crate.add_file(url, fetch_remote=False)
+        assert file_.id == url
+
+    out_path = tmpdir / 'ro_crate_out'
+    crate.write(out_path)
+    if fetch_remote:
+        assert (out_path / relpath).is_file()
+    else:
+        assert not (out_path / relpath).exists()
+
+
 @pytest.mark.parametrize(
     "fetch_remote,validate_url",
     list(product((False, True), repeat=2))


### PR DESCRIPTION
Fixes #103.

**Note:**
The unit test added by this PR is about twice as slow as all the others _combined_ (for me, at least). I've marked it as "slow", so that when running tests locally during development one can deselect it with `pytest -m "not slow". In absolute terms, it only adds a few seconds to the test run, so it's OK to run it in the CI build.