### PR TITLE
Package: update Python version support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     runs-on: ${{ matrix.os }}
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,6 +13,9 @@ authors:
   - family-names: Gaignard
     given-names: Alban
     orcid: https://orcid.org/0000-0002-3597-8557
+  - family-names: Huber
+    given-names: Sebastiaan
+    orcid: https://orcid.org/0000-0001-5845-8880
   - family-names: Leo
     given-names: Simone
     orcid: https://orcid.org/0000-0001-8271-5429

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,10 @@ $ pip install --upgrade pip
 $ pip install -r requirements.txt
 ```
 
-You can install ro-crate-py via `python setup.py install` or `pip install ./` In this case, to see the effect of any changes you make to the code, you need to reinstall it. However, **at the moment**, ro-crate-py can be run directly from the source tree (e.g., it does not have any extension modules, nor does it generate any other files during the setup process), so you can speed this up by hacking the venv installation dir (replace "3.6" with the actual Python version you are using):
+You can install ro-crate-py via `python setup.py install` or `pip install ./` In this case, to see the effect of any changes you make to the code, you need to reinstall it. However, **at the moment**, ro-crate-py can be run directly from the source tree (e.g., it does not have any extension modules, nor does it generate any other files during the setup process), so you can speed this up by hacking the venv installation dir (replace "3.7" with the actual Python version you are using):
 
 ```
-ln -sr . venv/lib/python3.6/site-packages/rocrate
+ln -sr . venv/lib/python3.7/site-packages/rocrate
 ```
 
 In this way, any changes to the code will be picked up immediately.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Status: **Alpha**
 
 ## Installing
 
-You will need Python 3.6 or later (Recommended: 3.7).
+You will need Python 3.7 or later (Recommended: 3.7).
 
 This library is easiest to install using [pip](https://docs.python.org/3/installing/):
 

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -31,6 +31,7 @@ __author__ = ", ".join((
     'Bert Droesbeke',
     'Ignacio Eguinoa',
     'Alban Gaignard',
+    'Sebastiaan Huber',
     'Simone Leo',
     'Luca Pireddu',
     'Laura Rodríguez-Navas',

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'Raül Sirvent',
         'Stian Soiland-Reyes'
     )),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     author_email='stain@apache.org',
     package_data={'': ['data/*.jsonld', 'templates/*.j2']},
     # SPDX, pending https://github.com/pombredanne/spdx-pypi-pep/pull/2
@@ -82,9 +82,10 @@ setup(
         'Intended Audience :: Information Technology',
         'Topic :: Software Development :: Libraries',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: System :: Archiving',

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'Bert Droesbeke',
         'Ignacio Eguinoa',
         'Alban Gaignard',
+        'Sebastiaan Huber',
         'Simone Leo',
         'Luca Pireddu',
         'Laura Rodríguez-Navas',


### PR DESCRIPTION
Fixes #114 

Python 3.6 has been EOL since 2021-12-23 and Python 3.9 and Python 3.10
have been released on 2020-10-05 and 2021-10-04, respectively.

The `setup.cfg` is updated to require Python 3.7 as a minimum and trove
classifiers are added for Python 3.9 and 3.10.

The CI workflow is updated to test against the new Python versions. The
version specifiers are wrapped in quotes, because without it they are
interpreted as floats first and `3.10` would become `3.1`.