### PR TITLE
Support detached crates

### DIFF
--- a/rocrate/model/file_or_dir.py
+++ b/rocrate/model/file_or_dir.py
@@ -45,5 +45,5 @@ class FileOrDir(DataEntity):
             if is_url(str(source)):
                 identifier = os.path.basename(source) if fetch_remote else source
             else:
-                identifier = os.path.basename(source)
+                identifier = "./" if source == "./" else os.path.basename(source)
         super().__init__(crate, identifier, properties)

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -102,9 +102,10 @@ TESTING_EXTRA_TERMS = {
 
 
 def metadata_class(descriptor_id):
-    if descriptor_id == Metadata.BASENAME:
+    basename = descriptor_id.rsplit("/", 1)[-1]
+    if basename == Metadata.BASENAME:
         return Metadata
-    elif descriptor_id == LegacyMetadata.BASENAME:
+    elif basename == LegacyMetadata.BASENAME:
         return LegacyMetadata
     else:
-        return ValueError("Invalid metadata descriptor ID: {descriptor_id!r}")
+        raise ValueError(f"Invalid metadata descriptor ID: {descriptor_id!r}")

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -35,11 +35,13 @@ class Metadata(File):
     BASENAME = "ro-crate-metadata.json"
     PROFILE = "https://w3id.org/ro/crate/1.1"
 
-    def __init__(self, crate, properties=None):
+    def __init__(self, crate, source=None, dest_path=None, properties=None):
+        if source is None and dest_path is None:
+            dest_path = self.BASENAME
         super().__init__(
             crate,
-            source=None,
-            dest_path=self.BASENAME,
+            source=source,
+            dest_path=dest_path,
             fetch_remote=False,
             validate_url=False,
             properties=properties
@@ -49,7 +51,7 @@ class Metadata(File):
 
     def _empty(self):
         # default properties of the metadata entry
-        val = {"@id": self.BASENAME,
+        val = {"@id": self.id,
                "@type": "CreativeWork",
                "conformsTo": {"@id": self.PROFILE},
                "about": {"@id": "./"}}

--- a/rocrate/model/root_dataset.py
+++ b/rocrate/model/root_dataset.py
@@ -24,11 +24,17 @@ from ..utils import iso_now
 
 class RootDataset(Dataset):
 
-    def __init__(self, crate, properties=None):
-        super().__init__(crate, dest_path='./', properties=properties)
-
-    def format_id(self, identifier):
-        return './'
+    def __init__(self, crate, source=None, dest_path=None, properties=None):
+        if source is None and dest_path is None:
+            dest_path = "./"
+        super().__init__(
+            crate,
+            source=source,
+            dest_path=dest_path,
+            fetch_remote=False,
+            validate_url=False,
+            properties=properties
+        )
 
     def _empty(self):
         val = {

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -149,7 +149,7 @@ class ROCrate():
             raise ValueError('metadata descriptor must be of type "CreativeWork"')
         try:
             root = entities[metadata["about"]["@id"]]
-        except KeyError:
+        except (KeyError, TypeError):
             raise ValueError("metadata descriptor does not reference the root entity")
         if root["@type"] != "Dataset":
             raise ValueError('root entity must be of type "Dataset"')

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -178,12 +178,12 @@ class ROCrate():
         metadata_id, root_id = self.find_root_entity_id(entities)
         MetadataClass = metadata_class(metadata_id)
         metadata_properties = entities.pop(metadata_id)
-        self.add(MetadataClass(self, properties=metadata_properties))
+        self.add(MetadataClass(self, metadata_id, properties=metadata_properties))
 
         root_entity = entities.pop(root_id)
         assert root_id == root_entity.pop('@id')
         parts = root_entity.pop('hasPart', [])
-        self.add(RootDataset(self, properties=root_entity))
+        self.add(RootDataset(self, root_id, properties=root_entity))
         preview_entity = entities.pop(Preview.BASENAME, None)
         if preview_entity and not gen_preview:
             self.add(Preview(self, source / Preview.BASENAME, properties=preview_entity))

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -20,7 +20,6 @@ import json
 import pytest
 import shutil
 import uuid
-import warnings
 import zipfile
 from copy import deepcopy
 from pathlib import Path

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -519,6 +519,7 @@ def test_find_root_multiple_entries(tmpdir):
                 "@id": root,
                 "@type": "Dataset",
                 "hasPart": [
+                    {"@id": nested},
                     {"@id": f"{nested}/ro-crate-metadata.json"},
                 ],
             },

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -20,6 +20,7 @@ import json
 import pytest
 import shutil
 import uuid
+import warnings
 import zipfile
 from pathlib import Path
 
@@ -498,8 +499,9 @@ def test_find_root(tmpdir, root, basename):
 
 def test_find_root_multiple_entries(tmpdir):
     """\
-    Detached RO-Crate with two entries that end in "ro-crate-metadata.json".
-    The library should find the correct metadata, root pair based on the fact
+    Detached RO-Crate with two entries that end in "ro-crate-metadata.json"
+    and satisfy all other requirements for metadata file descriptors. In this
+    case we try to find the correct (metadata, root) pair based on the fact
     that the actual root contains (i.e., references via hasPart) the "wrong"
     metadata file.
     """
@@ -546,6 +548,8 @@ def test_find_root_multiple_entries(tmpdir):
     crate_dir.mkdir()
     with open(crate_dir / "ro-crate-metadata.json", "wt") as f:
         json.dump(metadata, f, indent=4)
-    crate = ROCrate(crate_dir)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        crate = ROCrate(crate_dir)
     assert crate.metadata.id == metadata_id
     assert crate.root_dataset.id == root + "/"

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -491,9 +491,9 @@ def test_find_root(tmpdir, root, basename):
         with pytest.raises(KeyError):
             ROCrate(crate_dir)
     else:
-        ROCrate(crate_dir)
-        # assert crate.metadata.id == metadata_id
-        # assert crate.root_dataset.id == root_id
+        crate = ROCrate(crate_dir)
+        assert crate.metadata.id == metadata_id
+        assert crate.root_dataset.id == root_id
 
 
 def test_find_root_multiple_entries(tmpdir):
@@ -505,11 +505,12 @@ def test_find_root_multiple_entries(tmpdir):
     """
     root = "https://example.org/crate"
     nested = "https://example.org/crate/nested"
+    metadata_id = f"{root}/ro-crate-metadata.json"
     metadata = {
         "@context": "https://w3id.org/ro/crate/1.1/context",
         "@graph": [
             {
-                "@id": f"{root}/ro-crate-metadata.json",
+                "@id": metadata_id,
                 "@type": "CreativeWork",
                 "about": {"@id": root},
                 "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
@@ -544,6 +545,6 @@ def test_find_root_multiple_entries(tmpdir):
     crate_dir.mkdir()
     with open(crate_dir / "ro-crate-metadata.json", "wt") as f:
         json.dump(metadata, f, indent=4)
-    ROCrate(crate_dir)
-    # assert crate.metadata.id == metadata_id
-    # assert crate.root_dataset.id == root_id
+    crate = ROCrate(crate_dir)
+    assert crate.metadata.id == metadata_id
+    assert crate.root_dataset.id == root + "/"


### PR DESCRIPTION
Fixes #34.

See https://github.com/ResearchObject/ro-crate/pull/189, but note that the current spec already allows a root data entity id other than `./` (see #34).

Changes the `find_root_entity_id` method to support the general case where the metadata descriptor `@id` is an absolute URIs whose last path segment is `ro-crate-metadata.json[ld]`. Despite being able to handle a more general situation, the new implementation is actually much simpler and more efficient in the "standard" case of an attached RO-Crate, where the metadata descriptor `@id` is `ro-crate-metadata.json[ld]`: in this case, the search ends with an O(1) lookup on the existing entity map. If this fails, it looks for candidate URIs whose last path segment is `ro-crate-metadata.json[ld]`. If there are no candidates, it raises a `KeyError`; if there's only one candidate, it's selected as the metadata entity; if there's more than one, it tries to filter out those that don't satisfy all constraints (e.g., type is not `CreativeWork`). If there's still more than one candidate, it issues a warning and picks one using a heuristic.