### PR TITLE
Fix handling of hash marks in IDs

### DIFF
--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -140,7 +140,10 @@ def definition(crate_dir, suite, path, engine, engine_version):
     except ValueError:
         # For now, only support marking an existing file as a test definition
         raise ValueError(f"{source} is not in the crate dir {crate_dir}")
-    crate.add_test_definition(suite, source=source, dest_path=dest_path, engine=engine, engine_version=engine_version)
+    crate.add_test_definition(
+        add_hash(suite), source=source, dest_path=dest_path, engine=engine,
+        engine_version=engine_version
+    )
     crate.metadata.write(crate_dir)
 
 

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -24,18 +24,12 @@ from .rocrate import ROCrate
 from .model.computerlanguage import LANG_MAP
 from .model.testservice import SERVICE_MAP
 from .model.softwareapplication import APP_MAP
-from .utils import is_url
+from .model.contextentity import add_hash
 
 
 LANG_CHOICES = list(LANG_MAP)
 SERVICE_CHOICES = list(SERVICE_MAP)
 ENGINE_CHOICES = list(APP_MAP)
-
-
-def add_hash(id_):
-    if id_ is None or "#" in id_ or is_url(id_):
-        return id_
-    return "#" + id_
 
 
 class State:

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -33,7 +33,7 @@ ENGINE_CHOICES = list(APP_MAP)
 
 
 def add_hash(id_):
-    if id_ is None or id_.startswith("#") or is_url(id_):
+    if id_ is None or "#" in id_ or is_url(id_):
         return id_
     return "#" + id_
 

--- a/rocrate/model/contextentity.py
+++ b/rocrate/model/contextentity.py
@@ -70,12 +70,9 @@ class ContextEntity(Entity):
         super(ContextEntity, self).__init__(crate, identifier, properties)
 
     def format_id(self, identifier):
-        if is_url(identifier):
+        if not identifier or '#' in identifier or is_url(identifier):
             return identifier
-        elif identifier.startswith('#'):
-            return identifier
-        else:
-            return '#' + identifier
+        return '#' + identifier
 
     def getmany(self, instance):
         for json in as_list(instance.get(self.property)):

--- a/rocrate/model/contextentity.py
+++ b/rocrate/model/contextentity.py
@@ -64,15 +64,19 @@ The corresponding plural setter supports any iterable (e.g. list):
 """
 
 
+def add_hash(id_):
+    if id_ is None or "#" in id_ or is_url(id_):
+        return id_
+    return "#" + id_
+
+
 class ContextEntity(Entity):
 
     def __init__(self, crate, identifier=None, properties=None):
         super(ContextEntity, self).__init__(crate, identifier, properties)
 
     def format_id(self, identifier):
-        if not identifier or '#' in identifier or is_url(identifier):
-            return identifier
-        return '#' + identifier
+        return add_hash(identifier)
 
     def getmany(self, instance):
         for json in as_list(instance.get(self.property)):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -30,6 +30,7 @@ from rocrate.model.dataset import Dataset
 from rocrate.model.computationalworkflow import ComputationalWorkflow
 from rocrate.model.person import Person
 from rocrate.model.preview import Preview
+from rocrate.model.contextentity import ContextEntity
 
 
 RAW_REPO_URL = "https://raw.githubusercontent.com/ResearchObject/ro-crate-py"
@@ -132,6 +133,24 @@ def test_contextual_entities():
     new_person = crate.add(Person(crate, id_, {'name': 'Josiah Carberry'}))
     person_dereference = crate.dereference(id_)
     assert person_dereference is new_person
+
+
+def test_contextual_entities_hash(test_data_dir):
+    crate = ROCrate()
+    john = crate.add(Person(crate, "john", properties={"name": "John Doe"}))
+    assert john.id == "#john"
+    id_ = "https://orcid.org/0000-0002-1825-0097"
+    josiah = crate.add(Person(crate, id_, properties={"name": "Josiah Carberry"}))
+    assert josiah.id == id_
+    wf_path = test_data_dir / "ro-crate-galaxy-sortchangecase" / "sort-and-change-case.ga"
+    wf_dest_path = wf_path.name
+    wf = crate.add_workflow(wf_path, wf_dest_path, main=True, lang="galaxy")
+    step_id = f"{wf_dest_path}#sort"
+    step = crate.add(ContextEntity(crate, step_id, properties={
+        "@type": "HowToStep",
+    }))
+    wf["hasPart"] = [step]
+    assert step.id == step_id
 
 
 def test_properties():


### PR DESCRIPTION
* Completes the fix for #107 (#111 did not take into account the specification of the suite's `@id` in `add_test_definition`)
* Fixes a problem in the method that automatically adds a leading hash mark to contextual entity IDs (see https://github.com/ResearchObject/ro-crate/issues/200#issuecomment-1112649343)