### PR TITLE
Fix default workflow types initialization

### DIFF
--- a/rocrate/model/computationalworkflow.py
+++ b/rocrate/model/computationalworkflow.py
@@ -37,7 +37,7 @@ class ComputationalWorkflow(File):
     def _empty(self):
         return {
             "@id": self.id,
-            "@type": self.TYPES,
+            "@type": self.TYPES[:],
             "name": os.path.splitext(self.id)[0],
         }
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -393,3 +393,13 @@ def test_entity_as_mapping(tmpdir, helpers):
     }
     with pytest.raises(ValueError):
         correction["badProp"]
+
+
+def test_wf_types():
+    foo_crate = ROCrate()
+    foo_wf = foo_crate.add_workflow("foo.cwl", main=True)
+    assert "HowTo" not in foo_wf.type
+    foo_wf.type.append("HowTo")
+    bar_crate = ROCrate()
+    bar_wf = bar_crate.add_workflow("bar.cwl", main=True)
+    assert "HowTo" not in bar_wf.type


### PR DESCRIPTION
In `ComputationalWorkflow`, the default type list is a reference to the class variable:

```python
TYPES = ["File", "SoftwareSourceCode", "ComputationalWorkflow"]
```

This leads to weird behavior when multiple `ComputationalWorkflow` instances are created, even in different crates:

```python
crate1 = ROCrate()
wf1 = crate1.add_workflow("foo.cwl", main=True)
wf1.type.append("HowTo")
crate2 = ROCrate()
wf2 = crate2.add_workflow("bar.cwl")
print(wf2.type)
```

```
['File', 'SoftwareSourceCode', 'ComputationalWorkflow', 'HowTo']
```

This PR fixes the problem by initializing the types with a _copy_ of the class-level type list.