### PR TITLE
Allow additional types for root dataset

### DIFF
--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -151,8 +151,8 @@ class ROCrate():
             root = entities[metadata["about"]["@id"]]
         except (KeyError, TypeError):
             raise ValueError("metadata descriptor does not reference the root entity")
-        if root["@type"] != "Dataset":
-            raise ValueError('root entity must be of type "Dataset"')
+        if ("Dataset" not in root["@type"] if isinstance(root["@type"], list) else root["@type"] != "Dataset"):
+            raise ValueError('root entity must have "Dataset" among its types')
         return metadata["@id"], root["@id"]
 
     def find_root_entity_id(self, entities):

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -530,7 +530,7 @@ def test_find_root_bad_entities():
     # root type is not Dataset
     entities = deepcopy(orig_entities)
     entities["./"]["@type"] = "Thing"
-    with pytest.raises(ValueError, match="must be of type"):
+    with pytest.raises(ValueError, match="must have"):
         crate.find_root_entity_id(entities)
 
 
@@ -599,3 +599,30 @@ def test_find_root_multiple_entries():
     mod_entities = deepcopy(orig_entities)
     mod_entities["http://example.com/"]["@type"] = "Thing"
     check_finds_org(mod_entities)
+
+
+def test_find_root_multiple_types():
+    entities = {_["@id"]: _ for _ in [
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {"@id": "./"},
+            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+        },
+        {
+            "@id": "./",
+            "@type": ["Dataset", "RepositoryCollection"],
+        },
+    ]}
+    crate = ROCrate()
+    m_id, r_id = crate.find_root_entity_id(entities)
+    assert m_id == "ro-crate-metadata.json"
+    assert r_id == "./"
+    # "Dataset" not included
+    del entities["./"]["@type"][0]
+    with pytest.raises(ValueError):
+        crate.find_root_entity_id(entities)
+    # Check we're not trying to be too clever
+    entities["./"]["@type"] = "NotADataset"
+    with pytest.raises(ValueError):
+        crate.find_root_entity_id(entities)


### PR DESCRIPTION
Fixes #125.

See also: https://github.com/ResearchObject/ro-crate/issues/182