### PR TITLE
Test to check the performance of adding a data entity

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -129,7 +129,7 @@ def test_cli_init_exclude(test_data_dir, helpers):
     for p in exclude.split(",") + ["test/"]:
         assert not crate.dereference(p)
     for e in crate.data_entities:
-        assert not(e.id.startswith("test"))
+        assert not e.id.startswith("test")
 
 
 @pytest.mark.parametrize("cwd", [False, True])

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -19,6 +19,7 @@
 import datetime
 import json
 import tempfile
+import timeit
 import uuid
 from pathlib import Path
 
@@ -92,6 +93,20 @@ def test_data_entities(test_data_dir):
     assert set(crate.data_entities) == {file_, dataset, data_entity}
     part_ids = set(_["@id"] for _ in crate.root_dataset._jsonld["hasPart"])
     assert set(_.id for _ in (file_, dataset, data_entity)) <= part_ids
+
+
+def test_data_entities_perf():
+    """\
+    Test that adding a data entity happens in constant time.
+
+    See https://github.com/ResearchObject/ro-crate-py/pull/127 (this is a
+    regression test). The time required for 500 iterations should be ~0.01s if
+    entities are added in constant time, ~1s if they are added in linear time.
+    """
+    crate = ROCrate()
+    assert timeit.Timer(
+        "crate.add_file(uuid.uuid4().hex)", "import uuid", globals=locals()
+    ).timeit(500) < 0.1
 
 
 def test_remote_data_entities():

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -232,11 +232,11 @@ def test_exclude(test_data_dir, tmpdir, helpers):
         for p in exclude + ["test/"]:
             assert not crate.dereference(p)
             if out:
-                assert not(crate.source / p).exists()
+                assert not (crate.source / p).exists()
         for e in crate.data_entities:
-            assert not(e.id.startswith("test"))
+            assert not e.id.startswith("test")
         if out:
-            assert not(crate.source / "test").exists()
+            assert not (crate.source / "test").exists()
     crate_dir = test_data_dir / "ro-crate-galaxy-sortchangecase"
     (crate_dir / helpers.METADATA_FILE_NAME).unlink()
     exclude = ["test", "README.md"]


### PR DESCRIPTION
Adds a test to prevent the reintroduction of the performance bug fixed in #127.