### PR TITLE
Add methods for adding and updating JSON-LD directly (partials for WMS)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,9 @@ authors:
   - family-names: Huber
     given-names: Sebastiaan
     orcid: https://orcid.org/0000-0001-5845-8880
+  - family-names: Kinoshita
+    given-names: Bruno
+    orcid: https://orcid.org/0000-0001-8250-4074
   - family-names: Leo
     given-names: Simone
     orcid: https://orcid.org/0000-0001-8271-5429

--- a/README.md
+++ b/README.md
@@ -171,6 +171,77 @@ Note that entities can have multiple types, e.g.:
     "@type" = ["File", "SoftwareSourceCode"]
 ```
 
+#### Adding entities using JSON-LD data
+
+You can add and update an entity using JSON-LD. It does not need to be a fully
+compliant JSON-LD entity. This may be useful if a WMS does not contain all the
+information necessary to create an RO-Crate.
+
+In such cases, WMS's have two options, the first being to create an extra layer
+where the user provides the missing information in some other way (e.g. YAML,
+INI, custom code, etc.) and the WMS creates `ro-crate-py` objects and calls
+methods like `add` discussed in the previous section.
+
+The second option is using a JSON file with JSON-LD properties such as `@id`
+and `@type`, and letting `ro-crate-py` automatically create the objects and
+add or update the entities to the RO-Crate file. The following example shows
+how that can be applied for a WMS that does not record workflow license, nor
+the list of authors.
+
+```json
+{
+  "@graph": [
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "license": "https://spdx.org/licenses/Apache-2.0.html",
+      "author": [
+        {
+          "@id": "https://orcid.org/0000-0000-0000-0000"
+        }
+      ]
+    },
+    {
+      "@id": "./",
+      "author": [
+        {
+          "@id": "https://orcid.org/0000-0000-0000-0000"
+        }
+      ]
+    }
+  ]
+}
+```
+
+If the WMS is written in Python, the required code and logic to read this
+file and populate the RO-Crate would be similar to this example:
+
+```python
+
+crate = ROCrate()
+# ...
+# Create the RO-Crate file and add as much WMS provenance data as possible,
+# and then:
+json_file = Path(config_path, 'rocrate.json')
+with open(json_file, 'r') as f:
+    json_content = json.load(f)
+
+if '@graph' in json_content:
+    for jsonld_node in json_content['@graph']:
+        # NOTE: @id and @type are important attributes when adding,
+        #       but to update you only need @id. Other keys that
+        #       start with @ are discarded when updating.
+        crate.add_or_update_jsonld(jsonld_node)
+
+# Write RO-Crate ZIP.
+crate.write_zip(Path(config_path, "rocrate.zip"))
+```
+
+The `ROCrate` class provides the methods `add`, `update`, and `add_or_update`
+to, respectively, add a new entity, update an existing entity, or handle
+deciding whether to add (if `@id` does not exist in the JSON-LD metadata)
+or update an entity automatically.
+
 ### Consuming an RO-Crate
 
 An existing RO-Crate package can be loaded from a directory or zip file:
@@ -278,7 +349,7 @@ Note that data entities (e.g., workflows) must already be present in the directo
 cd test/test-data/ro-crate-galaxy-sortchangecase
 ```
 
-This directory is already an ro-crate. Delete the metadata file to get a plain directory tree:
+This directory is already an RO-Crate. Delete the metadata file to get a plain directory tree:
 
 ```bash
 rm ro-crate-metadata.json
@@ -314,7 +385,6 @@ rocrate add test-suite -i test1
 rocrate add test-instance test1 http://example.com -r jobs -i test1_1
 rocrate add test-definition test1 test/test1/sort-and-change-case-test.yml -e planemo -v '>=0.70'
 ```
-
 
 ## License
 

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -33,6 +33,7 @@ __author__ = ", ".join((
     'Ignacio Eguinoa',
     'Alban Gaignard',
     'Sebastiaan Huber',
+    'Bruno Kinoshita',
     'Simone Leo',
     'Luca Pireddu',
     'Laura Rodríguez-Navas',

--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -32,7 +32,7 @@ class Entity(MutableMapping):
         if identifier:
             self.id = self.format_id(identifier)
         else:
-            self.id = "#%s" % uuid.uuid4()
+            self.id = f"#{uuid.uuid4()}"
         if properties:
             empty = self._empty()
             empty.update(properties)
@@ -46,7 +46,7 @@ class Entity(MutableMapping):
         return str(identifier)
 
     def __repr__(self):
-        return "<%s %s>" % (self.id, self.type)
+        return f"<{self.id} {self.type}>"
 
     def properties(self):
         return self._jsonld

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -558,11 +558,7 @@ class ROCrate():
         entity: Entity = self.get(entity_id)
         if not entity:
             raise ValueError(f"entity {entity_id} does not exist in the RO-Crate")
-        # Keys starting with @ are removed here to avoid messing up things.
-        # https://github.com/ResearchObject/ro-crate-py/pull/149#issuecomment-1487039274
-        for key in list(jsonld.keys()):
-            if key.startswith('@'):
-                del jsonld[key]
+        jsonld = {k: v for k, v in jsonld.items() if not k.startswith('@')}
         entity._jsonld.update(jsonld)
         return entity
 

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -26,7 +26,6 @@ import tempfile
 from collections import OrderedDict
 from pathlib import Path
 from urllib.parse import urljoin
-from typing import Dict
 
 from .model.contextentity import ContextEntity
 from .model.entity import Entity
@@ -62,30 +61,6 @@ def pick_type(json_entity, type_map, fallback=None):
 
 
 class ROCrate():
-    """A class that represents the ROCrate archive.
-
-    Attributes:
-        exclude (list):
-            A list of file names to be excluded.
-        default_entities (list):
-            A list of default entities to be written to the ROCrate file.
-            It is an empty list when the object is created, and gets
-            populated when entities are added (but only it the type of these
-            entities matches RootDataset, Metadata, LegacyMetadata, Preview).
-        contextual_entities (list):
-            A list of entities to be written to the ROCrate file.
-            It is an empty list when the object is created, and gets
-            populated when entities are added (when they are not default
-            entities).
-        uuid (str):
-            A unique ID for the ROCrate file.
-        arcp_base_uri (str):
-            The base arcp (archive and package) URI. Used to
-        preview (Entity):
-            The entity representing the preview of the ROCrate (optional).
-        source (Path):
-            The ROCrate directory (e.g. where an ROCrate was extracted).
-    """
 
     def __init__(self, source=None, gen_preview=False, init=False, exclude=None):
         self.exclude = exclude
@@ -348,7 +323,7 @@ class ROCrate():
 
     add_directory = add_dataset
 
-    def add(self, *entities: Entity):
+    def add(self, *entities):
         """\
         Add one or more entities to this RO-Crate.
 
@@ -538,15 +513,15 @@ class ROCrate():
         self.metadata.extra_terms.update(TESTING_EXTRA_TERMS)
         return definition
 
-    def add_jsonld(self, jsonld: Dict[str, Entity]) -> Entity:
-        """Add a JSON-LD entity to the RO-Crate.
+    def add_jsonld(self, jsonld):
+        """Add a JSON-LD dictionary as an entity to the RO-Crate.
 
-        An ``@id`` must always be present in the JSON-LD dictionary.
+        An ``@id`` must be present in the JSON-LD dictionary.
 
         Args:
             jsonld: A JSON-LD dictionary.
         Return:
-            The entity added to the RO-Crate file.
+            The entity added to the RO-Crate.
         Raises:
             ValueError: if the ``jsonld`` object is empty or ``None`` or if the
                 entity already exists (found via ID).
@@ -562,15 +537,15 @@ class ROCrate():
             properties=jsonld
         ))
 
-    def update_jsonld(self, jsonld: Dict[str, Entity]) -> Entity:
-        """Update a JSON-LD entity in the RO-Crate.
+    def update_jsonld(self, jsonld):
+        """Update an entity in the RO-Crate from a JSON-LD dictionary.
 
-        An ``@id`` must always be present in the JSON-LD dictionary.
+        An ``@id`` must be present in the JSON-LD dictionary.
 
         Args:
             jsonld: A JSON-LD dictionary.
         Return:
-            The entity or list of entities added to the RO-Crate file.
+            The updated entity.
         Raises:
             ValueError: if the ``jsonld`` object is empty or ``None``, if the
                 ``@id`` was not provided, or if the entity was not found.
@@ -587,14 +562,14 @@ class ROCrate():
         return entity
 
     def add_or_update_jsonld(self, jsonld):
-        """Add or update a JSON-LD entity in the RO-Crate.
+        """Add or update an entity from a JSON-LD dictionary.
 
-        An ``@id`` must always be present in the JSON-LD dictionary.
+        An ``@id`` must be present in the JSON-LD dictionary.
 
         Args:
             jsonld: A JSON-LD dictionary.
         Return:
-            The entity or list of entities added to the RO-Crate file.
+            The added or updated entity.
         Raises:
             ValueError: if the ``jsonld`` object is empty or ``None`` or if the
                 ``@id`` was not provided.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -557,7 +557,7 @@ class ROCrate():
         # TODO: Do we need to remove all keys starting with `@`? What
         #       if we did not provide a `@type` in the `jsonld`?
         if not entity:
-            raise ValueError(f"entity {entity_id} does exists in the RO-Crate")
+            raise ValueError(f"entity {entity_id} does not exist in the RO-Crate")
         entity._jsonld.update(jsonld)
         return entity
 
@@ -577,8 +577,6 @@ class ROCrate():
         if not jsonld or "@id" not in jsonld:
             raise ValueError("you must provide a non-empty JSON-LD dictionary")
         entity_id = jsonld.get("@id")
-        if not entity_id:
-            raise ValueError("you must provide a valid entity ID")
         entity: Entity = self.get(entity_id)
         if not entity:
             return self.add_jsonld(jsonld)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -514,12 +514,12 @@ class ROCrate():
         return definition
 
     def add_jsonld(self, jsonld):
-        """Add a JSON-LD dictionary as an entity to the RO-Crate.
+        """Add a JSON-LD dictionary as a contextual entity to the RO-Crate.
 
-        The `@id` and `@type` items must be present in the JSON-LD dictionary.
+        The `@id` and `@type` keys must be present in the JSON-LD dictionary.
 
         Args:
-            jsonld: A JSON-LD dictionary containing @id and @type, at least, set.
+            jsonld: A JSON-LD dictionary containing at least `@id` and `@type`.
         Return:
             The entity added to the RO-Crate.
         Raises:

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -61,6 +61,30 @@ def pick_type(json_entity, type_map, fallback=None):
 
 
 class ROCrate():
+    """A class that represents the ROCrate archive.
+
+    Attributes:
+        exclude (list):
+            A list of file names to be excluded.
+        default_entities (list):
+            A list of default entities to be written to the ROCrate file.
+            It is an empty list when the object is created, and gets
+            populated when entities are added (but only it the type of these
+            entities matches RootDataset, Metadata, LegacyMetadata, Preview).
+        contextual_entities (list):
+            A list of entities to be written to the ROCrate file.
+            It is an empty list when the object is created, and gets
+            populated when entities are added (when they are not default
+            entities).
+        uuid (str):
+            A unique ID for the ROCrate file.
+        arcp_base_uri (str):
+            The base arcp (archive and package) URI. Used to
+        preview (Entity):
+            The entity representing the preview of the ROCrate (optional).
+        source (Path):
+            The ROCrate directory (e.g. where an ROCrate was extracted).
+    """
 
     def __init__(self, source=None, gen_preview=False, init=False, exclude=None):
         self.exclude = exclude
@@ -323,7 +347,7 @@ class ROCrate():
 
     add_directory = add_dataset
 
-    def add(self, *entities):
+    def add(self, *entities: Entity):
         """\
         Add one or more entities to this RO-Crate.
 

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -516,15 +516,15 @@ class ROCrate():
     def add_jsonld(self, jsonld):
         """Add a JSON-LD dictionary as an entity to the RO-Crate.
 
-        An ``@id`` must be present in the JSON-LD dictionary.
+        An `@id` must be present in the JSON-LD dictionary.
 
         Args:
             jsonld: A JSON-LD dictionary.
         Return:
             The entity added to the RO-Crate.
         Raises:
-            ValueError: if the ``jsonld`` object is empty or ``None`` or if the
-                entity already exists (found via ID).
+            ValueError: if the jsonld object is empty or None or if the
+                entity already exists (found via @id).
         """
         if not jsonld or "@id" not in jsonld:
             raise ValueError("you must provide a non-empty JSON-LD dictionary")
@@ -540,22 +540,22 @@ class ROCrate():
     def update_jsonld(self, jsonld):
         """Update an entity in the RO-Crate from a JSON-LD dictionary.
 
-        An ``@id`` must be present in the JSON-LD dictionary.
+        An `@id` must be present in the JSON-LD dictionary.
 
         Args:
             jsonld: A JSON-LD dictionary.
         Return:
             The updated entity.
         Raises:
-            ValueError: if the ``jsonld`` object is empty or ``None``, if the
-                ``@id`` was not provided, or if the entity was not found.
+            ValueError: if the jsonld object is empty or None, if @id was not
+              provided, or if the entity was not found.
         """
         if not jsonld or "@id" not in jsonld:
             raise ValueError("you must provide a non-empty JSON-LD dictionary")
         entity_id = jsonld.pop("@id")
         entity: Entity = self.get(entity_id)
-        # TODO: Do we need to remove all keys starting with ``@``? What
-        #       if we did not provide a ``@type`` in the ``jsonld``?
+        # TODO: Do we need to remove all keys starting with `@`? What
+        #       if we did not provide a `@type` in the `jsonld`?
         if not entity:
             raise ValueError(f"entity {entity_id} does exists in the RO-Crate")
         entity._jsonld.update(jsonld)
@@ -564,15 +564,15 @@ class ROCrate():
     def add_or_update_jsonld(self, jsonld):
         """Add or update an entity from a JSON-LD dictionary.
 
-        An ``@id`` must be present in the JSON-LD dictionary.
+        An `@id` must be present in the JSON-LD dictionary.
 
         Args:
             jsonld: A JSON-LD dictionary.
         Return:
             The added or updated entity.
         Raises:
-            ValueError: if the ``jsonld`` object is empty or ``None`` or if the
-                ``@id`` was not provided.
+            ValueError: if the jsonld object is empty or None or if @id was not
+              provided.
         """
         if not jsonld or "@id" not in jsonld:
             raise ValueError("you must provide a non-empty JSON-LD dictionary")

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -526,8 +526,8 @@ class ROCrate():
             ValueError: if the jsonld object is empty or None or if the
                 entity already exists (found via @id).
         """
-        required_keys = ("@id", "@type")
-        if not jsonld or not all(required_key in jsonld for required_key in required_keys):
+        required_keys = {"@id", "@type"}
+        if not jsonld or not required_keys.issubset(jsonld):
             raise ValueError("you must provide a non-empty JSON-LD dictionary with @id and @type set")
         entity_id = jsonld.pop("@id")
         if self.get(entity_id):

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Ignacio Eguinoa',
         'Alban Gaignard',
         'Sebastiaan Huber',
+        'Bruno Kinoshita',
         'Simone Leo',
         'Luca Pireddu',
         'Laura Rodríguez-Navas',

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -157,6 +157,8 @@ def test_update_jsonld(test_data_dir):
     assert updated_entity.type == 'CreativeWork'
     assert updated_entity['name'] == 'No potatoes today'
 
+    assert '@type' in update_dict
+
 
 # --- add or update
 

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -85,7 +85,9 @@ def test_add_jsonld(test_data_dir):
         '@type': 'CreativeWork',
         'name': 'A test entity'
     })
-    assert crate.get(new_entity_id) is not None
+    new_entity = crate.get(new_entity_id)
+    assert new_entity.type == 'CreativeWork'
+    assert new_entity["name"] == 'A test entity'
 
 
 # --- update
@@ -141,7 +143,7 @@ def test_update_jsonld(test_data_dir):
     })
 
     entity_added = crate.get(new_entity_id)
-    assert entity_added is not None
+    assert entity_added.type == 'CreativeWork'
     assert entity_added['name'] == 'A test entity'
 
     entity_added['name'] = 'No potatoes today'
@@ -193,7 +195,9 @@ def test_add_or_update_add_jsonld(test_data_dir):
         '@type': 'CreativeWork',
         'name': 'A test entity'
     })
-    assert crate.get(new_entity_id) is not None
+    new_entity = crate.get(new_entity_id)
+    assert new_entity.type == 'CreativeWork'
+    assert new_entity["name"] == 'A test entity'
 
 
 def test_add_or_update_update_jsonld(test_data_dir):
@@ -209,7 +213,7 @@ def test_add_or_update_update_jsonld(test_data_dir):
     })
 
     entity_added = crate.get(new_entity_id)
-    assert entity_added is not None
+    assert entity_added.type == 'CreativeWork'
     assert entity_added['name'] == 'A test entity'
 
     entity_added['name'] = 'No potatoes today'

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -1,0 +1,206 @@
+# Copyright 2019-2022 The University of Manchester, UK
+# Copyright 2020-2022 Vlaams Instituut voor Biotechnologie (VIB), BE
+# Copyright 2020-2022 Barcelona Supercomputing Center (BSC), ES
+# Copyright 2020-2022 Center for Advanced Studies, Research and Development in Sardinia (CRS4), IT
+# Copyright 2022 École Polytechnique Fédérale de Lausanne, CH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the JSON-LD methods of the ROCrate object."""
+
+from uuid import uuid4
+
+import pytest
+
+from rocrate.rocrate import ROCrate
+
+
+# --- add
+
+
+def test_add_jsonld_raises_json_is_none():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.add_jsonld(None)
+
+
+def test_add_jsonld_raises_json_is_empty():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.add_jsonld({})
+
+
+def test_add_jsonld_raises_json_missing_id():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.add_jsonld({
+            '@type': 'ContextEntity'
+        })
+
+
+def test_add_jsonld_raises_json_duplicate_id(test_data_dir):
+    crate_dir = test_data_dir / 'read_crate'
+    crate = ROCrate(crate_dir)
+
+    with pytest.raises(ValueError, match='.*already exists.*'):
+        crate.add_jsonld({
+            '@id': './',
+            'license': 'NA'
+        })
+
+
+def test_add_jsonld(test_data_dir):
+    crate_dir = test_data_dir / 'read_crate'
+    crate = ROCrate(crate_dir)
+
+    new_entity_id = f'#{uuid4()}'
+
+    crate.add_jsonld({
+        '@id': new_entity_id,
+        '@type': 'ContextEntity',
+        'name': 'A test entity'
+    })
+    assert crate.get(new_entity_id) is not None
+
+
+# --- update
+
+
+def test_update_jsonld_raises_json_is_none():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.update_jsonld(None)
+
+
+def test_update_jsonld_raises_json_is_empty():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.update_jsonld({})
+
+
+def test_update_jsonld_raises_json_missing_id():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.update_jsonld({
+            '@type': 'ContextEntity'
+        })
+
+
+def test_update_jsonld_raises_id_not_found(test_data_dir):
+    crate_dir = test_data_dir / 'read_crate'
+    crate = ROCrate(crate_dir)
+
+    missing_entity_id = f'#{uuid4()}'
+
+    with pytest.raises(ValueError, match='.*does not exist.*'):
+        crate.update_jsonld({
+            '@id': missing_entity_id,
+            '@type': 'ContextEntity',
+            'name': 'This entity does not exist in the RO-Crate'
+        })
+
+
+def test_update_jsonld(test_data_dir):
+    crate_dir = test_data_dir / 'read_crate'
+    crate = ROCrate(crate_dir)
+
+    new_entity_id = f'#{uuid4()}'
+
+    crate.add_jsonld({
+        '@id': new_entity_id,
+        '@type': 'ContextEntity',
+        'name': 'A test entity'
+    })
+
+    entity_added = crate.get(new_entity_id)
+    assert entity_added is not None
+    assert entity_added['name'] == 'A test entity'
+
+    entity_added['name'] = 'No potatoes today'
+    crate.update_jsonld(entity_added._jsonld)
+
+    updated_entity = crate.get(new_entity_id)
+    assert entity_added.id == updated_entity.id
+    assert entity_added.type == updated_entity.type
+    assert updated_entity['name'] == 'No potatoes today'
+
+
+# --- add or update
+
+
+def test_add_or_update_jsonld_raises_json_is_none():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.add_or_update_jsonld(None)
+
+
+def test_add_orupdate_jsonld_raises_json_is_empty():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.add_or_update_jsonld({})
+
+
+def test_add_or_update_jsonld_raises_json_missing_id():
+    crate = ROCrate()
+
+    with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
+        crate.add_or_update_jsonld({
+            '@type': 'ContextEntity'
+        })
+
+
+def test_add_or_update_add_jsonld(test_data_dir):
+    crate_dir = test_data_dir / 'read_crate'
+    crate = ROCrate(crate_dir)
+
+    new_entity_id = f'#{uuid4()}'
+
+    crate.add_or_update_jsonld({
+        '@id': new_entity_id,
+        '@type': 'ContextEntity',
+        'name': 'A test entity'
+    })
+    assert crate.get(new_entity_id) is not None
+
+
+def test_add_or_update_update_jsonld(test_data_dir):
+    crate_dir = test_data_dir / 'read_crate'
+    crate = ROCrate(crate_dir)
+
+    new_entity_id = f'#{uuid4()}'
+
+    crate.add_jsonld({
+        '@id': new_entity_id,
+        '@type': 'ContextEntity',
+        'name': 'A test entity'
+    })
+
+    entity_added = crate.get(new_entity_id)
+    assert entity_added is not None
+    assert entity_added['name'] == 'A test entity'
+
+    entity_added['name'] = 'No potatoes today'
+    crate.add_or_update_jsonld(entity_added._jsonld)
+
+    updated_entity = crate.get(new_entity_id)
+    assert entity_added.id == updated_entity.id
+    assert entity_added.type == updated_entity.type
+    assert updated_entity['name'] == 'No potatoes today'

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -47,7 +47,7 @@ def test_add_jsonld_raises_json_missing_id():
 
     with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
         crate.add_jsonld({
-            '@type': 'ContextEntity'
+            '@type': 'CreativeWork'
         })
 
 
@@ -82,7 +82,7 @@ def test_add_jsonld(test_data_dir):
 
     crate.add_jsonld({
         '@id': new_entity_id,
-        '@type': 'ContextEntity',
+        '@type': 'CreativeWork',
         'name': 'A test entity'
     })
     assert crate.get(new_entity_id) is not None
@@ -110,7 +110,7 @@ def test_update_jsonld_raises_json_missing_id():
 
     with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
         crate.update_jsonld({
-            '@type': 'ContextEntity'
+            '@type': 'CreativeWork'
         })
 
 
@@ -123,7 +123,7 @@ def test_update_jsonld_raises_id_not_found(test_data_dir):
     with pytest.raises(ValueError, match='.*does not exist.*'):
         crate.update_jsonld({
             '@id': missing_entity_id,
-            '@type': 'ContextEntity',
+            '@type': 'CreativeWork',
             'name': 'This entity does not exist in the RO-Crate'
         })
 
@@ -136,7 +136,7 @@ def test_update_jsonld(test_data_dir):
 
     crate.add_jsonld({
         '@id': new_entity_id,
-        '@type': 'ContextEntity',
+        '@type': 'CreativeWork',
         'name': 'A test entity'
     })
 
@@ -152,7 +152,7 @@ def test_update_jsonld(test_data_dir):
 
     updated_entity = crate.get(new_entity_id)
     assert entity_added.id == updated_entity.id
-    assert updated_entity.type == 'ContextEntity'
+    assert updated_entity.type == 'CreativeWork'
     assert updated_entity['name'] == 'No potatoes today'
 
 
@@ -178,7 +178,7 @@ def test_add_or_update_jsonld_raises_json_missing_id():
 
     with pytest.raises(ValueError, match='.*non-empty JSON-LD.*'):
         crate.add_or_update_jsonld({
-            '@type': 'ContextEntity'
+            '@type': 'CreativeWork'
         })
 
 
@@ -190,7 +190,7 @@ def test_add_or_update_add_jsonld(test_data_dir):
 
     crate.add_or_update_jsonld({
         '@id': new_entity_id,
-        '@type': 'ContextEntity',
+        '@type': 'CreativeWork',
         'name': 'A test entity'
     })
     assert crate.get(new_entity_id) is not None
@@ -204,7 +204,7 @@ def test_add_or_update_update_jsonld(test_data_dir):
 
     crate.add_jsonld({
         '@id': new_entity_id,
-        '@type': 'ContextEntity',
+        '@type': 'CreativeWork',
         'name': 'A test entity'
     })
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -18,6 +18,7 @@
 
 import datetime
 import json
+import os
 import tempfile
 import timeit
 import uuid
@@ -95,6 +96,7 @@ def test_data_entities(test_data_dir):
     assert set(_.id for _ in (file_, dataset, data_entity)) <= part_ids
 
 
+@pytest.mark.skipif(os.name != "posix", reason="CI sometimes fails on macOS")
 def test_data_entities_perf():
     """\
     Test that adding a data entity happens in constant time.


### PR DESCRIPTION
Closes #146 

@simleo I was toying with the code you suggest a little in the Autosubmit code base. But then I thought that if I wrote those functions in Autosubmit, other WMS would still require to do the same.

It occurred to me, then, maybe add these new methods to `ro-crate-py` instead? I made this draft pull request after testing it with Autosubmit. You can see the current implementation here: https://earth.bsc.es/gitlab/es/autosubmit/-/merge_requests/317/diffs

Most of the code in `autosubmit.py` in that merge request is retrieving metadata about the Autosubmit workflow configuration and execution logs and data. But what previously was

```py
        yaml_file = Path(experiment_path, 'conf/rocrate.yml')
        try:
            with open(yaml_file) as f:
                try:
                    yaml_content = YAMLParserFactory().create_parser().load(f)
                except Exception as e:
...
...
# Create RO-Crate and add Autosubmit data
...
...
        # Fill-in the pre-populated data
        crate.license = yaml_content['license']
        # These two sets keep track of the authors and orgs to add to the CRATE
        authors = set()
        organizations = set()
        for author in yaml_content['authors']:
            authors.add(author['orcid'])
            organizations.add(author['ror'])
            crate.add(Person(crate, author['orcid'], {
                'name': author['name'],
                'contactPoint': { '@id': f'mailto: {author["email"]}' },
                'affiliation': { '@id': f'mailto: {author["ror"]}' }
            }))
            crate.add(ContextEntity(crate, f'mailto: {author["email"]}', {
                '@type': 'ContactPoint',
                'contactType': 'Author',
                'email': author['email'],
                'identifier': author['email'],
                'url': author['orcid'],
            }))
            crate.add(ContextEntity(crate, author['ror'], {
                '@type': 'Organization',
                'name': author['organisation_name']
            }))
        crate.creator = { '@id': id for id in authors }
        crate.publisher = { '@id': id for id in organizations }

```

Now became, basically

```py
        json_file = Path(experiment_path, 'conf/rocrate.json')
        try:
            with open(json_file, 'r') as f:
                try:
                    json_content = json.load(f)
                except Exception as e:
                    raise AutosubmitCritical(f'Failed to parse $expid/conf/rocrate.json pre-populated file {json_file}', 7011, e)
        except IOError:
...
...
# Create RO-Crate and add Autosubmit data
# because ro-crate-py's add replaces data.
...
...
            if '@graph' in json_content:
                for jsonld_node in json_content['@graph']:
                    crate.add_or_update_jsonld(jsonld_node)

            # Write RO-Crate ZIP.
            crate.write_zip(Path(experiment_path, "rocrate.zip"))
```

I liked the general structure, and I think it could be applied to other WMS that preferred to go JSON-LD → ro-crate-py → JSON-LD, instead of what I had in the merge request before, YAML → Python → ro-crate-py → JSON-LD (where YAML → Python could possibly vary between WMS's).

If it sounds like a good idea I will add docs & tests :+1: Thank you for the code example.

Also added another commit with comments & f-strings for code that I was having a look, and trying to understand before using it. Let me know if you prefer that I drop that commit and open a separate pull request for it.

Cheers
Bruno
