### PR TITLE
Fix test skip

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -18,7 +18,7 @@
 
 import datetime
 import json
-import os
+import sys
 import tempfile
 import timeit
 import uuid
@@ -98,7 +98,7 @@ def test_data_entities(test_data_dir):
     assert set(_.id for _ in (file_, dataset, data_entity)) <= part_ids
 
 
-@pytest.mark.skipif(os.name != "posix", reason="CI sometimes fails on macOS")
+@pytest.mark.skipif(sys.platform == "darwin", reason="CI sometimes fails on macOS")
 def test_data_entities_perf():
     """\
     Test that adding a data entity happens in constant time.


### PR DESCRIPTION
This should hopefully fix the skip clause for `test_data_entities_perf`.