### PR TITLE
Fix is_url

### DIFF
--- a/rocrate/utils.py
+++ b/rocrate/utils.py
@@ -33,7 +33,7 @@ def is_url(string):
     parts = urlsplit(string)
     if os.name == "nt" and len(parts.scheme) == 1:
         return False
-    return all((parts.scheme, parts.path))
+    return bool(parts.scheme)
 
 
 def iso_now():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,7 +18,7 @@
 
 import pytest
 
-from rocrate.utils import subclasses, get_norm_value
+from rocrate.utils import subclasses, get_norm_value, is_url
 
 
 class Pet:
@@ -53,3 +53,12 @@ def test_get_norm_value():
     assert get_norm_value({"@id": "#xyz"}, "name") == []
     with pytest.raises(ValueError):
         get_norm_value({"@id": "#xyz", "name": [["foo"]]}, "name")
+
+
+def test_is_url():
+    assert is_url("http://example.com/index.html")
+    assert is_url("http://example.com/")
+    assert is_url("http://example.com")
+    assert not is_url("/etc/")
+    assert not is_url("/etc")
+    assert not is_url("/")


### PR DESCRIPTION
Fixes #167.

The `is_url` utility failed to recognize URLs that don't have a path part, e.g. `http://example.com`.