### PR TITLE
Add help text for some CLI args

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,9 +318,12 @@ $ rocrate init --help
 Usage: rocrate init [OPTIONS]
 
 Options:
-  --gen-preview
-  -e, --exclude CSV
-  -c, --crate-dir PATH
+  --gen-preview         Generate a HTML preview file for the crate.
+  -e, --exclude NAME    Exclude files or directories from the metadata file.
+                        NAME may be a single name or a comma-separated list of
+                        names.
+  -c, --crate-dir PATH  The path to the root data entity of the crate.
+                        Defaults to the current working directory.
   --help                Show this message and exit.
 ```
 
@@ -409,8 +412,13 @@ Usage: rocrate add workflow [OPTIONS] PATH
 
 Options:
   -l, --language [cwl|galaxy|knime|nextflow|snakemake|compss|autosubmit]
-  -c, --crate-dir PATH
-  -P, --property KEY=VALUE
+                                  The workflow language.
+  -c, --crate-dir PATH            The path to the root data entity of the
+                                  crate. Defaults to the current working
+                                  directory.
+  -P, --property KEY=VALUE        Add an additional property to the metadata
+                                  for this entity. Can be used multiple times
+                                  to set multiple properties.
   --help                          Show this message and exit.
 ```
 

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -88,7 +88,7 @@ def cli():
     "--exclude",
     type=CSV,
     metavar="NAME",
-    help="Exclude files or directories from the RO-Crate. NAME may be a single name or a comma-separated list of names.",
+    help="Exclude files or directories from the metadata file. NAME may be a single name or a comma-separated list of names.",
 )
 @OPTION_CRATE_PATH
 def init(crate_dir, gen_preview, exclude):

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -88,7 +88,7 @@ def cli():
     "--exclude",
     type=CSV,
     metavar="NAME",
-    help="Exclude files or directories from the metadata file. NAME may be a single name or a comma-separated list of names.",
+    help="Exclude files or directories from the RO-Crate. NAME may be a single name or a comma-separated list of names.",
 )
 @OPTION_CRATE_PATH
 def init(crate_dir, gen_preview, exclude):


### PR DESCRIPTION
Adds some help text to some CLI commands (not all of them because I'm not sure about all of the options). I was particularly confused by the `--exclude` option so I focused on that.

File also reformatted with black hence some extra changes.