### PR TITLE
Add ro-crate instantiation from a dictionary

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
 

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -30,8 +30,11 @@ def read_metadata(metadata_path):
     Return a tuple of two elements: the context; a dictionary that maps entity
     ids to the entities themselves.
     """
-    with open(metadata_path) as f:
-        metadata = json.load(f)
+    if isinstance(metadata_path, dict):
+        metadata = metadata_path
+    else:
+        with open(metadata_path) as f:
+            metadata = json.load(f)
     try:
         context = metadata['@context']
         graph = metadata['@graph']


### PR DESCRIPTION
Fixes #178.

```python
from rocrate.rocrate import ROCrate

metadata = {
    "@context": "https://w3id.org/ro/crate/1.1/context",
    "@graph": [
        {
            "@id": "ro-crate-metadata.json",
            "@type": "CreativeWork",
            "about": {"@id": "./"},
            "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"}
        },
        {
            "@id": "./",
            "@type": "Dataset",
            "creator": {"@id": "#josiah"},
            "hasPart": {"@id": "http://example.org/foo"}
        },
        {
            "@id": "http://example.org/foo",
            "@type": "File"
        },
        {
            "@id": "#josiah",
            "@type": "Person",
            'name': 'Josiah Carberry'
        },
    ]
}

crate = ROCrate(metadata)
crate.write("crate")
```

If the metadata points to nonexistent local files or directories, the behavior when writing the crate is as described in #136 (see also the unit test added in this PR).