### PR TITLE
Raise exception if trying to set a dict with no id as property value

### DIFF
--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -102,6 +102,9 @@ class Entity(MutableMapping):
         if key.startswith("@"):
             raise KeyError(f"cannot set '{key}'")
         values = value if isinstance(value, list) else [value]
+        for v in values:
+            if isinstance(v, dict) and "@id" not in v:
+                raise ValueError(f"no @id in {v}")
         ref_values = [{"@id": _.id} if isinstance(_, Entity) else _ for _ in values]
         self._jsonld[key] = ref_values if isinstance(value, list) else ref_values[0]
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -365,6 +365,11 @@ def test_entity_as_mapping(tmpdir, helpers):
     crate_dir.mkdir()
     with open(crate_dir / helpers.METADATA_FILE_NAME, "wt") as f:
         json.dump(metadata, f, indent=4)
+    with pytest.raises(ValueError):
+        crate = ROCrate(crate_dir)
+    del metadata["@graph"][2]["badProp"]
+    with open(crate_dir / helpers.METADATA_FILE_NAME, "wt") as f:
+        json.dump(metadata, f, indent=4)
     crate = ROCrate(crate_dir)
     person = crate.dereference(orcid)
     exp_len = len([_ for _ in metadata["@graph"] if _["@id"] == orcid][0])
@@ -411,6 +416,7 @@ def test_entity_as_mapping(tmpdir, helpers):
         "application/json",
         "https://www.json.org",
     }
+    correction._jsonld["badProp"] = {"k": "v"}
     with pytest.raises(ValueError):
         correction["badProp"]
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -365,7 +365,7 @@ def test_entity_as_mapping(tmpdir, helpers):
     crate_dir.mkdir()
     with open(crate_dir / helpers.METADATA_FILE_NAME, "wt") as f:
         json.dump(metadata, f, indent=4)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # due to "badProp", which has no "@id"
         crate = ROCrate(crate_dir)
     del metadata["@graph"][2]["badProp"]
     with open(crate_dir / helpers.METADATA_FILE_NAME, "wt") as f:
@@ -416,7 +416,9 @@ def test_entity_as_mapping(tmpdir, helpers):
         "application/json",
         "https://www.json.org",
     }
-    correction._jsonld["badProp"] = {"k": "v"}
+    with pytest.raises(ValueError):
+        correction["badProp"] = {"k": "v"}  # value has no "@id"
+    correction._jsonld["badProp"] = {"k": "v"}  # force set using _jsonld
     with pytest.raises(ValueError):
         correction["badProp"]
 


### PR DESCRIPTION
Closes #190.

Adds a check for dict values without `@id` to `Entity.__setitem__`.