### PR TITLE
Fix dataset id when adding a local dir with trailing slash

### DIFF
--- a/rocrate/model/file_or_dir.py
+++ b/rocrate/model/file_or_dir.py
@@ -47,5 +47,5 @@ class FileOrDir(DataEntity):
             if is_url(str(source)):
                 identifier = os.path.basename(source) if fetch_remote else source
             else:
-                identifier = os.path.basename(str(source).rstrip(os.sep))
+                identifier = os.path.basename(str(source).rstrip("/"))
         super().__init__(crate, identifier, properties)

--- a/rocrate/model/file_or_dir.py
+++ b/rocrate/model/file_or_dir.py
@@ -47,5 +47,5 @@ class FileOrDir(DataEntity):
             if is_url(str(source)):
                 identifier = os.path.basename(source) if fetch_remote else source
             else:
-                identifier = "./" if source == "./" else os.path.basename(source)
+                identifier = os.path.basename(str(source).rstrip(os.sep))
         super().__init__(crate, identifier, properties)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -41,7 +41,7 @@ from rocrate.model import (
 RAW_REPO_URL = "https://raw.githubusercontent.com/ResearchObject/ro-crate-py"
 
 
-def test_dereferencing(test_data_dir, helpers):
+def test_dereferencing(test_data_dir, helpers, monkeypatch):
     crate = ROCrate(gen_preview=True)
 
     # verify default entities
@@ -68,6 +68,12 @@ def test_dereferencing(test_data_dir, helpers):
 
     # alias
     assert crate.get(readme_url) is readme_entity
+
+    # dereference local dir added with trailing slash
+    monkeypatch.chdir(test_data_dir)
+    local_dir = "test_add_dir/"
+    local_dir_entity = crate.add_dataset(local_dir)
+    assert crate.dereference(local_dir) is local_dir_entity
 
 
 @pytest.mark.parametrize("name", [".foo", "foo.", ".foo/", "foo./"])


### PR DESCRIPTION
See https://github.com/ResearchObject/ro-crate-py/issues/206#issuecomment-2520523621

Minimally:

```pycon
>>> from rocrate.rocrate import ROCrate
>>> crate = ROCrate()
>>> folder = crate.add_dataset("folder/")
>>> folder.id
'#7e28c8e2-54ef-4c2e-af09-3bcbaaa986e3'
```