### PR TITLE
fix: Error message for incompatible constructor options

### DIFF
--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -92,7 +92,7 @@ class ROCrate():
             self.add(RootDataset(self), Metadata(self))
         elif init:
             if isinstance(source, dict):
-                raise ValueError("parameter init is not compatible with a JsonLD source")
+                raise ValueError("parameter 'init' is not compatible with a dict source")
             self.__init_from_tree(source, gen_preview=gen_preview)
         else:
             source = self.__read(source, gen_preview=gen_preview)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -91,6 +91,8 @@ class ROCrate():
             # create a new ro-crate
             self.add(RootDataset(self), Metadata(self))
         elif init:
+            if isinstance(source, dict):
+                raise ValueError("parameter init is not compatible with a JsonLD source")
             self.__init_from_tree(source, gen_preview=gen_preview)
         else:
             source = self.__read(source, gen_preview=gen_preview)

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -595,3 +595,5 @@ def test_from_dict(tmpdir):
     for entity in d1, d2, f1:
         entity.source = None
     crate.write(out_path)
+    with pytest.raises(ValueError):
+        ROCrate(metadata, init=True)


### PR DESCRIPTION
The constructor arguments `init` and passing a jsonld dictionary as source are mutually exclusive.

At the moment, when passing a `dict` containing JSONLD as source to the contructor and setting `init=True`, a cryptic error message is shown:

```python
from rocrate.rocrate import ROCrate
crate = ROCrate({"@context": "http://example.com", "@graph": []}, init=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dbauer/projects/ro-crate-py/rocrate/rocrate.py", line 94, in __init__
    self.__init_from_tree(source, gen_preview=gen_preview)
  File "/home/dbauer/projects/ro-crate-py/rocrate/rocrate.py", line 101, in __init_from_tree
    top_dir = Path(top_dir)
  File "/home/dbauer/.local/share/uv/python/cpython-3.9.21-linux-x86_64-gnu/lib/python3.9/pathlib.py", line 1082, in __new__
    self = cls._from_parts(args, init=False)
  File "/home/dbauer/.local/share/uv/python/cpython-3.9.21-linux-x86_64-gnu/lib/python3.9/pathlib.py", line 707, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/home/dbauer/.local/share/uv/python/cpython-3.9.21-linux-x86_64-gnu/lib/python3.9/pathlib.py", line 691, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not dict
```

This PR replaces this error with a message telling the user what the issue actually is:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dbauer/projects/ro-crate-py/rocrate/rocrate.py", line 95, in __init__
    raise ValueError("parameter init is not compatible with a JsonLD source")
ValueError: parameter init is not compatible with a JsonLD source
```