### PR TITLE
Preview template function return values

### DIFF
--- a/rocrate/model/preview.py
+++ b/rocrate/model/preview.py
@@ -78,8 +78,7 @@ class Preview(File):
                 for obj in a:
                     if obj is not str:
                         return True
-            else:
-                return False
+            return False
 
         template.close()
         context_entities = []

--- a/rocrate/model/preview.py
+++ b/rocrate/model/preview.py
@@ -70,7 +70,7 @@ class Preview(File):
                 if a._jsonld and a._jsonld['name']:
                     return a._jsonld['name']
                 else:
-                    return a
+                    return str(a)
 
         @template_function
         def is_object_list(a):


### PR DESCRIPTION
While working on type annotations, I noticed that these two functions seem to not always return what is expected:

- is_object_list does sometimes return nothing instead of a boolean.
- stringify not always returns a string.