### PR TITLE
Proposing add_formal_parameter function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ ENV/
 
 # vim 
 *.swp
+.DS_Store
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,7 @@ ENV/
 
 # vim 
 *.swp
+
+# other
 .DS_Store
 /.vscode

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,6 +46,10 @@ author:
   - family-names: Soiland-Reyes
     given-names: Stian
     orcid: https://orcid.org/0000-0001-9842-9718
+  - family-names: Thomas
+    given-names: Laurent
+    orcid: https://orcid.org/0000-0001-7686-3249
+   
 title: "ro-crate-py"
 version: 0.13.0
 doi: 10.5281/zenodo.3956493

--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Options:
 * Copyright 2024-2025 Data Centre, SciLifeLab, SE
 * Copyright 2024-2025 National Institute of Informatics (NII), JP
 * Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+* Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 
 Licensed under the
 Apache License, version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>,

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/read_test_metadata.py
+++ b/examples/read_test_metadata.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64"]
+build-backend = "setuptools.build_meta"

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -57,6 +57,7 @@ Copyright 2022-2025 École Polytechnique Fédérale de Lausanne, CH
 Copyright 2024-2025 Data Centre, SciLifeLab, SE
 Copyright 2024-2025 National Institute of Informatics (NII), JP
 Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 """
 __license__ = ("Apache License, version 2.0 "
                "<https://www.apache.org/licenses/LICENSE-2.0>")

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -44,7 +44,8 @@ __author__ = ", ".join((
     'Luca Pireddu',
     'Laura Rodríguez-Navas',
     'Raül Sirvent',
-    'Stian Soiland-Reyes'
+    'Stian Soiland-Reyes',
+    'Laurent Thomas'
 ))
 __copyright__ = """\
 Copyright 2019-2025 The University of Manchester, UK

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/memory_buffer.py
+++ b/rocrate/memory_buffer.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/__init__.py
+++ b/rocrate/model/__init__.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/computationalworkflow.py
+++ b/rocrate/model/computationalworkflow.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/computerlanguage.py
+++ b/rocrate/model/computerlanguage.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/contextentity.py
+++ b/rocrate/model/contextentity.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/creativework.py
+++ b/rocrate/model/creativework.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/data_entity.py
+++ b/rocrate/model/data_entity.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/file_or_dir.py
+++ b/rocrate/model/file_or_dir.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/person.py
+++ b/rocrate/model/person.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/preview.py
+++ b/rocrate/model/preview.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/root_dataset.py
+++ b/rocrate/model/root_dataset.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/softwareapplication.py
+++ b/rocrate/model/softwareapplication.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testdefinition.py
+++ b/rocrate/model/testdefinition.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testinstance.py
+++ b/rocrate/model/testinstance.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testservice.py
+++ b/rocrate/model/testservice.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testsuite.py
+++ b/rocrate/model/testsuite.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -20,7 +20,6 @@
 # limitations under the License.
 
 import errno
-from typing import Literal, Optional
 import uuid
 import zipfile
 import atexit
@@ -629,52 +628,47 @@ class ROCrate():
         self.root_dataset.append_to("mentions", action)
         return action
 
-    def add_formal_parameter(self,
-                             name: str,
-                             additionalType: Literal["Text", "Boolean", "Integer", "File", "Dataset"],
-                             identifier: Optional[str] = None,
-                             description: Optional[str] = None,
-                             valueRequired=False,
-                             defaultValue=None) -> ContextEntity:
+    def add_formal_parameter(
+            self,
+            additionalType,
+            identifier=None,
+            name=None,
+            description=None,
+            valueRequired=False,
+            defaultValue=None,
+            properties=None
+    ):
+        """\
+        Add a FormalParameter to describe an input or output of a workflow.
+
+        A FormalParameter represents an input or output slot of a workflow, not
+        the actual value taken by a parameter. For further information see
+        https://w3id.org/ro/wfrun/workflow
+
+        Returns the created FormalParameter entity, which can be associated to
+        a workflow (e.g. as an input) using the syntax:
+          workflow_entity.append_to("input", formal_parameter_entity)
         """
-        Create a FormalParameter to describe an input or output of a workflow.
-
-        A FormalParameter describes the data-type of an input or output, not its value.
-        The value a parameter takes for a run of the workflow is documented by a separate Data entity,
-        referring to the associated FormalParameter via the `exampleOfWork` attribute.
-
-        additionalType
-        --------------
-        The type of the parameter. It should be typically one of the following (although it is not enforced):
-        - Text (for strings)
-        - Boolean
-        - Integer
-        - File
-        - Dataset (for directories)
-
-
-        returns
-        -------
-        The created FormalParameter entity.
-        It can be associated to a workflow e.g as an input using the syntax
-        >>> workflow_entity.append_to("input", formal_parameter_entity)
-        """
-        properties = {"@type": "FormalParameter",
-                      "additionalType": additionalType,
-                      "valueRequired": valueRequired,
-                      "conformsTo": {"@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"},
-                      "name": name
-                      }
-
+        if properties is None:
+            properties = {}
+        props = {
+            "@type": "FormalParameter",
+            "additionalType": additionalType,
+            "valueRequired": valueRequired,
+            "conformsTo": {
+                "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+            }
+        }
+        if name:
+            props["name"] = name
         if description:
-            properties["description"] = description
-
+            props["description"] = description
         if defaultValue:
-            properties["defaultValue"] = defaultValue
-
-        return self.add(ContextEntity(self,
-                                      identifier=identifier,
-                                      properties=properties))
+            props["defaultValue"] = defaultValue
+        props.update(properties)
+        return self.add(
+            ContextEntity(self, identifier=identifier, properties=props)
+        )
 
     def add_jsonld(self, jsonld):
         """Add a JSON-LD dictionary as a contextual entity to the RO-Crate.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -20,6 +20,7 @@
 # limitations under the License.
 
 import errno
+from typing import Literal, Optional
 import uuid
 import zipfile
 import atexit
@@ -627,6 +628,54 @@ class ROCrate():
             action["result"] = result
         self.root_dataset.append_to("mentions", action)
         return action
+    
+    def add_formal_parameter(self,
+                             name:str,
+                             additionalType : Literal["Text", "Boolean", "Integer", "File", "Dataset"], 
+                             identifier: Optional[str] = None, 
+                             description : Optional[str] = None,
+                             valueRequired = False,
+                             defaultValue = None) -> ContextEntity:
+        """
+        Create a FormalParameter to describe an input or output of a workflow.    
+        
+        A FormalParameter describes the data-type of an input or output, not its value.  
+        The value a parameter takes for a run of the workflow is documented by a separate Data entity, referring to the associated FormalParameter via the `exampleOfWork` attribute.
+
+        additionalType
+        --------------
+        The type of the parameter. It should be typically one of the following (although it is not enforced):
+        - Text (for strings)
+        - Boolean
+        - Integer
+        - File
+        - Dataset (for directories)
+
+
+        returns
+        -------
+        The created FormalParameter entity.  
+        It can be associated to a workflow e.g as an input using the syntax
+        >>> workflow_entity.append_to("input", formal_parameter_entity)
+        """
+        properties = {"@type": "FormalParameter",
+                      "additionalType" : additionalType,
+                      "valueRequired" : valueRequired,
+                      "conformsTo": {
+                                "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+                                },
+                      "name" : name
+                    }
+        
+        if description:
+            properties["description"] = description
+
+        if defaultValue:
+            properties["defaultValue"] = defaultValue
+
+        return self.add(ContextEntity(self, 
+                                      identifier = identifier,
+                                      properties = properties))
 
     def add_jsonld(self, jsonld):
         """Add a JSON-LD dictionary as a contextual entity to the RO-Crate.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -630,9 +630,9 @@ class ROCrate():
 
     def add_formal_parameter(
             self,
+            name,
             additionalType,
             identifier=None,
-            name=None,
             description=None,
             valueRequired=False,
             defaultValue=None,
@@ -653,14 +653,13 @@ class ROCrate():
             properties = {}
         props = {
             "@type": "FormalParameter",
+            "name": name,
             "additionalType": additionalType,
             "valueRequired": valueRequired,
             "conformsTo": {
                 "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
             }
         }
-        if name:
-            props["name"] = name
         if description:
             props["description"] = description
         if defaultValue:

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -628,19 +628,20 @@ class ROCrate():
             action["result"] = result
         self.root_dataset.append_to("mentions", action)
         return action
-    
+
     def add_formal_parameter(self,
-                             name:str,
-                             additionalType : Literal["Text", "Boolean", "Integer", "File", "Dataset"], 
-                             identifier: Optional[str] = None, 
-                             description : Optional[str] = None,
-                             valueRequired = False,
-                             defaultValue = None) -> ContextEntity:
+                             name: str,
+                             additionalType: Literal["Text", "Boolean", "Integer", "File", "Dataset"],
+                             identifier: Optional[str] = None,
+                             description: Optional[str] = None,
+                             valueRequired=False,
+                             defaultValue=None) -> ContextEntity:
         """
-        Create a FormalParameter to describe an input or output of a workflow.    
-        
-        A FormalParameter describes the data-type of an input or output, not its value.  
-        The value a parameter takes for a run of the workflow is documented by a separate Data entity, referring to the associated FormalParameter via the `exampleOfWork` attribute.
+        Create a FormalParameter to describe an input or output of a workflow.
+
+        A FormalParameter describes the data-type of an input or output, not its value.
+        The value a parameter takes for a run of the workflow is documented by a separate Data entity,
+        referring to the associated FormalParameter via the `exampleOfWork` attribute.
 
         additionalType
         --------------
@@ -654,28 +655,26 @@ class ROCrate():
 
         returns
         -------
-        The created FormalParameter entity.  
+        The created FormalParameter entity.
         It can be associated to a workflow e.g as an input using the syntax
         >>> workflow_entity.append_to("input", formal_parameter_entity)
         """
         properties = {"@type": "FormalParameter",
-                      "additionalType" : additionalType,
-                      "valueRequired" : valueRequired,
-                      "conformsTo": {
-                                "@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
-                                },
-                      "name" : name
-                    }
-        
+                      "additionalType": additionalType,
+                      "valueRequired": valueRequired,
+                      "conformsTo": {"@id": "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"},
+                      "name": name
+                      }
+
         if description:
             properties["description"] = description
 
         if defaultValue:
             properties["defaultValue"] = defaultValue
 
-        return self.add(ContextEntity(self, 
-                                      identifier = identifier,
-                                      properties = properties))
+        return self.add(ContextEntity(self,
+                                      identifier=identifier,
+                                      properties=properties))
 
     def add_jsonld(self, jsonld):
         """Add a JSON-LD dictionary as a contextual entity to the RO-Crate.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/utils.py
+++ b/rocrate/utils.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/vocabs.py
+++ b/rocrate/vocabs.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,8 @@ setup(
         'Luca Pireddu',
         'Laura Rodríguez-Navas',
         'Raül Sirvent',
-        'Stian Soiland-Reyes'
+        'Stian Soiland-Reyes',
+        'Laurent Thomas'
     )),
     python_requires='>=3.9',
     author_email='stain@apache.org',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_readwrite.py
+++ b/test/test_readwrite.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_test_metadata.py
+++ b/test/test_test_metadata.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_workflow_ro_crate.py
+++ b/test/test_workflow_ro_crate.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -83,15 +83,14 @@ def test_add_action(tmpdir):
 
 def test_add_formal_parameter():
     crate = ROCrate()
-
     name = "test_json_param"
     additionalType = "File"
     encodingFormat = "application/json"
-
-    fp = crate.add_formal_parameter(name=name,
-                                    additionalType=additionalType,
-                                    properties={"encodingFormat": encodingFormat})
-
+    fp = crate.add_formal_parameter(
+        name=name,
+        additionalType=additionalType,
+        properties={"encodingFormat": encodingFormat}
+    )
     assert fp.type == "FormalParameter"
     assert fp.get("name") == name
     assert fp.get("additionalType") == additionalType
@@ -105,10 +104,11 @@ def test_add_formal_parameter():
 
     # Test with defaultValue and valueRequired
     defaultValue = "default"
-    fp2 = crate.add_formal_parameter(name="param_string",
-                                     additionalType="Text",
-                                     defaultValue=defaultValue,
-                                     valueRequired=True)
-
+    fp2 = crate.add_formal_parameter(
+        name="param_string",
+        additionalType="Text",
+        defaultValue=defaultValue,
+        valueRequired=True
+    )
     assert fp2.get("defaultValue") == defaultValue
     assert fp2.get("valueRequired")

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -96,7 +96,7 @@ def test_add_formal_parameter():
     assert fp.get("name") == name
     assert fp.get("additionalType") == additionalType
     assert not fp.get("valueRequired")
-    assert not "defaultValue" in fp
+    assert "defaultValue" not in fp
     assert fp.get("encodingFormat") == encodingFormat
     assert fp.get("conformsTo") == "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
 

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -79,3 +79,36 @@ def test_add_action(tmpdir):
     assert "result" not in activate_action
     assert activate_action.get("name") == f"Run 2 of {instrument.id}"
     assert activate_action.get("endTime") == "2018-10-25T16:48:41.021563"
+
+
+def test_add_formal_parameter():
+    crate = ROCrate()
+
+    name = "test_json_param"
+    additionalType = "File"
+    encodingFormat = "application/json"
+
+    fp = crate.add_formal_parameter(name=name,
+                                    additionalType=additionalType,
+                                    properties={"encodingFormat": encodingFormat})
+
+    assert fp.type == "FormalParameter"
+    assert fp.get("name") == name
+    assert fp.get("additionalType") == additionalType
+    assert not fp.get("valueRequired")
+    assert not "defaultValue" in fp
+    assert fp.get("encodingFormat") == encodingFormat
+    assert fp.get("conformsTo") == "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE"
+
+    list_formal_parameter = crate.get_by_type("FormalParameter")
+    assert list_formal_parameter == [fp]
+
+    # Test with defaultValue and valueRequired
+    defaultValue = "default"
+    fp2 = crate.add_formal_parameter(name="param_string",
+                                     additionalType="Text",
+                                     defaultValue=defaultValue,
+                                     valueRequired=True)
+
+    assert fp2.get("defaultValue") == defaultValue
+    assert fp2.get("valueRequired")

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/add_boilerplate.py
+++ b/tools/add_boilerplate.py
@@ -42,6 +42,7 @@ START_YEAR_MAP = {
     "Data Centre, SciLifeLab, SE": "2024",
     "National Institute of Informatics (NII), JP": "2024",
     "Senckenberg Society for Nature Research (SGN), DE": "2025",
+    "European Molecular Biology Laboratory (EMBL), Heidelberg, DE": "2025",
 }
 THIS_YEAR = str(datetime.date.today().year)
 BOILERPLATE_START = "Copyright [yyyy] [name of copyright owner]"

--- a/tools/add_boilerplate.py
+++ b/tools/add_boilerplate.py
@@ -6,6 +6,7 @@
 # Copyright 2024-2025 Data Centre, SciLifeLab, SE
 # Copyright 2024-2025 National Institute of Informatics (NII), JP
 # Copyright 2025 Senckenberg Society for Nature Research (SGN), DE
+# Copyright 2025 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Following yesterday's call, here is a small PR proposing the addition of a function to facilitate the definition of FormalParameters in a workflow crate.

It makes use of type hints, which is available from python 3.5, support could be added for earlier version by adding the [typing package](https://pypi.org/project/typing/) to the list of dependencies, checking the version of python to only install if needed.

I am happy to write tests and documentation for this function if you think that's a valid addition.
Currently it can be tested with 

```python
from rocrate.rocrate import ROCrate
from pprint import pprint

crate = ROCrate()
formal_parameter = crate.add_formal_parameter(identifier = "my_param",
                                              additionalType = "Text",
                                              name = "my_param",
                                              description = "",
                                              valueRequired = False,
                                              defaultValue = "")
pprint(formal_parameter.as_jsonld())
``` 

Actually for testing I typically install the package in editable mode like so
`pip install -e .`
but I got an exception that it's not possible

`DEPRECATION: Legacy editable install of rocrate==0.13.0 from file:///Users/thomasl/Documents/repos/ro-crate-py (setup.py develop) is deprecated. pip 25.1 will enforce this behaviour change. A possible replacement is to add a pyproject.toml or enable --use-pep517, and use setuptools >= 64. If the resulting installation is not behaving as expected, try using --config-settings editable_mode=compat. Please consult the setuptools documentation for more information. Discussion can be found at https://github.com/pypa/pip/issues/11457`

So I was wondering how you test it usually.
I also had issues with test discovery, but that's maybe something with my VScode config.

Cheers !