### PR TITLE
add_action: do not auto link the action from RDE mentions

### DIFF
--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -629,7 +629,6 @@ class ROCrate():
             action["object"] = object
         if result:
             action["result"] = result
-        self.root_dataset.append_to("mentions", action)
         return action
 
     def add_formal_parameter(

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -55,7 +55,6 @@ def test_add_action(tmpdir):
     )
     assert create_action.type == "CreateAction"
     create_actions = crate.get_by_type("CreateAction")
-    assert crate.root_dataset.get("mentions") == create_actions
     assert create_actions == [create_action]
     assert create_action.get("instrument") is instrument
     assert create_action.get("object") == [f_in, param]
@@ -74,7 +73,6 @@ def test_add_action(tmpdir):
         }
     )
     assert activate_action.type == "ActivateAction"
-    assert crate.root_dataset.get("mentions") == [create_action, activate_action]
     assert activate_action.get("instrument") is instrument
     assert activate_action.get("object") == [f_out]
     assert "result" not in activate_action


### PR DESCRIPTION
Fixes #228.

The method has no way of knowing whether the action should be in `mentions` or not, so I removed the auto-add. We could add an extra argument for that, but then clients might as well update `crate.root_dataset["mentions"]` themselves.