### PR TITLE
Unquote file or dir source before creating the entity

### DIFF
--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -69,10 +69,7 @@ class Dataset(FileOrDir):
         if self.source is None:
             abs_out_path.mkdir(parents=True, exist_ok=True)
         else:
-            if self.crate.mode == Mode.READ:
-                path = unquote(str(self.source))
-            else:
-                path = self.source
+            path = self.source
             if not Path(path).exists():
                 raise FileNotFoundError(
                     errno.ENOENT, os.strerror(errno.ENOENT), path
@@ -97,10 +94,7 @@ class Dataset(FileOrDir):
             yield from self._stream_folder_from_path(chunk_size)
 
     def _stream_folder_from_path(self, chunk_size=8192):
-        if self.crate.mode == Mode.READ:
-            path = unquote(str(self.source))
-        else:
-            path = self.source
+        path = self.source
         if not Path(path).exists():
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), str(path)

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -31,7 +31,7 @@ from io import BytesIO, StringIO
 from urllib.parse import unquote
 
 from .file_or_dir import FileOrDir
-from ..utils import is_url, iso_now, Mode
+from ..utils import is_url, iso_now
 
 
 class File(FileOrDir):
@@ -78,11 +78,7 @@ class File(FileOrDir):
             # Allows to record a File entity whose @id does not exist, see #73
             warnings.warn(f"No source for {self.id}")
         else:
-            if self.crate.mode == Mode.READ:
-                in_file_path = unquote(str(self.source))
-            else:
-                in_file_path = self.source
-            self._copy_file(in_file_path, out_file_path)
+            self._copy_file(self.source, out_file_path)
 
     def _stream_from_stream(self, stream):
         size = 0
@@ -149,8 +145,4 @@ class File(FileOrDir):
             # Allows to record a File entity whose @id does not exist, see #73
             warnings.warn(f"No source for {self.id}")
         else:
-            if self.crate.mode == Mode.READ:
-                path = unquote(str(self.source))
-            else:
-                path = self.source
-            yield from self._stream_from_file(path, chunk_size)
+            yield from self._stream_from_file(self.source, chunk_size)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -31,7 +31,7 @@ import warnings
 
 from collections import OrderedDict
 from pathlib import Path
-from urllib.parse import urljoin
+from urllib.parse import urljoin, unquote
 
 from packaging.version import Version
 
@@ -199,7 +199,7 @@ class ROCrate():
                 if is_url(id_):
                     instance = cls(self, id_, properties=entity)
                 else:
-                    instance = cls(self, source / id_, id_, properties=entity)
+                    instance = cls(self, source / unquote(id_), id_, properties=entity)
             self.add(instance)
             if instance.type == "Dataset":
                 self.__add_parts(as_list(entity.get("hasPart", [])), entities, source)

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -509,17 +509,31 @@ def test_percent_escape(test_data_dir, tmpdir, helpers):
     f_path = test_data_dir / "read_crate" / "with space.txt"
     f1 = crate.add_file(f_path)
     assert f1.id == "with%20space.txt"
+    assert f1.source.is_file()
+    assert str(f1.source) == str(f_path)
     f2 = crate.add_file(f_path, dest_path="subdir/with space.txt")
     assert f2.id == "subdir/with%20space.txt"
-    f3 = crate.add_file(test_data_dir / "read_crate" / "without%20space.txt")
+    assert f2.source.is_file()
+    assert str(f2.source) == str(f_path)
+    f3_path = test_data_dir / "read_crate" / "without%20space.txt"
+    f3 = crate.add_file(f3_path)
     assert f3.id == "without%2520space.txt"
+    assert f3.source.is_file()
+    assert str(f3.source) == str(f3_path)
     d_path = test_data_dir / "read_crate" / "a b"
     d1 = crate.add_dataset(d_path)
     assert d1.id == "a%20b/"
+    assert d1.source.is_dir()
+    assert str(d1.source) == str(d_path)
     d2 = crate.add_dataset(d_path, dest_path="subdir/a b")
     assert d2.id == "subdir/a%20b/"
-    d3 = crate.add_dataset(test_data_dir / "read_crate" / "j%20k")
+    assert d2.source.is_dir()
+    assert str(d2.source) == str(d_path)
+    d3_path = test_data_dir / "read_crate" / "j%20k"
+    d3 = crate.add_dataset(d3_path)
     assert d3.id == "j%2520k/"
+    assert d3.source.is_dir()
+    assert str(d3.source) == str(d3_path)
     out_path = tmpdir / "ro_crate_out"
     crate.write(out_path)
     json_entities = helpers.read_json_entities(out_path)
@@ -553,6 +567,19 @@ def test_percent_escape(test_data_dir, tmpdir, helpers):
     assert (unpack_path / "a b" / "c d.txt").is_file()
     assert (unpack_path / "subdir" / "a b" / "c d.txt").is_file()
     assert (unpack_path / "j%20k" / "l%20m.txt").is_file()
+    rcrate = ROCrate(out_path)
+    rf1 = rcrate.get("with%20space.txt")
+    assert str(rf1.source) == str(out_path / "with space.txt")
+    rf2 = rcrate.get("subdir/with%20space.txt")
+    assert str(rf2.source) == str(out_path / "subdir/with space.txt")
+    rf3 = rcrate.get("without%2520space.txt")
+    assert str(rf3.source) == str(out_path / "without%20space.txt")
+    df1 = rcrate.get("a%20b/")
+    assert str(df1.source) == str(out_path / "a b/")
+    df2 = rcrate.get("subdir/a%20b/")
+    assert str(df2.source) == str(out_path / "subdir/a b/")
+    df3 = rcrate.get("j%2520k/")
+    assert str(df3.source) == str(out_path / "j%20k/")
 
 
 def test_stream_empty_file(test_data_dir, tmpdir):


### PR DESCRIPTION
Fixes #226.

When reading a crate, the JSON-LD `@id` of files and directories is unquoted _before_ creating the `File` or `Dataset` entity, so that the `.source` attribute corresponds to the "input path" at all times (see the changes to `test_percent_escape`).
