### PR TITLE
Read crates whose metadata contains JSON-LD value objects

### DIFF
--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -105,9 +105,13 @@ class Entity(MutableMapping):
         if key.startswith("@"):
             raise KeyError(f"cannot set '{key}'")
         values = value if isinstance(value, list) else [value]
-        for v in values:
+        for i, v in enumerate(values):
             if isinstance(v, dict) and "@id" not in v:
-                raise ValueError(f"no @id in {v}")
+                # https://www.w3.org/TR/json-ld11/#value-objects
+                if "@value" in v:
+                    values[i] = v["@value"]
+                else:
+                    raise ValueError(f"no @id in {v}")
         ref_values = [{"@id": _.id} if isinstance(_, Entity) else _ for _ in values]
         self._jsonld[key] = ref_values if isinstance(value, list) else ref_values[0]
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -553,3 +553,41 @@ def test_entity_in_properties(tmpdir):
     assert out_authors[1] is out_bob
     assert out_alice == alice
     assert out_bob == bob
+
+
+def test_value_objects(tmpdir):
+    description = "A collection of my pictures"
+    date_published = "2024-05-17T01:04:52+01:00"
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"},
+                "about": {"@id": "./"},
+            },
+            {
+                "@id": "./",
+                "@type": "Dataset",
+                "name": "My pictures",
+                "description": {
+                    "@value": description,
+                    "@language": "en"
+                },
+                "datePublished": {
+                    "@value": date_published,
+                    "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                },
+                "license": "CC0-1.0",
+            },
+        ]
+    }
+    crate = ROCrate(metadata)
+    assert crate.root_dataset.get("description") == description
+    assert crate.root_dataset.get("datePublished") == date_published
+    out_path = tmpdir / "ro_crate_out"
+    crate.write(out_path)
+    rcrate = ROCrate(out_path)
+    assert rcrate.root_dataset.get("description") == description
+    assert rcrate.root_dataset.get("datePublished") == date_published


### PR DESCRIPTION
Adds minimal support for JSON-LD [value objects](https://www.w3.org/TR/json-ld11/#value-objects): now an entry like:

```json
"description": {
    "@value": "A collection of my pictures",
    "@language": "en"
}
```

is treated like:

```json
"description": "A collection of my pictures"
```

whereas previously we crashed with:

```
ValueError: no @id in {'@value': 'A collection of my pictures', '@language': 'en'}
```

Note that the validator has recently added support for value objects in https://github.com/crs4/rocrate-validator/pull/116.