### PR TITLE
Support for detached crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ but you could also write the crate as attached, after tweaking the data entities
 
 ```python
 sample_file.fetch_remote = True
-sample_file["localPath"] = "sample_file.txt"
 test_file_galaxy.fetch_remote = True
 read_crate.write("/tmp/crate")
 ```
@@ -366,7 +365,22 @@ This leads to the following structure on the file system:
     `-- test_file_galaxy.txt
 ```
 
-Note that we did not have to set `localPath` for `test_file_galaxy` because it was already set in the original crate that we read from the remote url.
+Note that `test_file_galaxy` was written as `test-data/test-file-galaxy.txt` relative to the crate root: this is due to the fact that the original crate specifies `"localPath": "test-data/test-file-galaxy.txt"`. In contrast, `localPath` is not specified for the other file, so the library applies the default behavior of using the basename as the relative path. This can be changed by setting `localPath` on the file entity:
+
+```python
+sample_file["localPath"] = "test-data/sample_file.txt"
+read_crate.write("/tmp/crate2")
+```
+
+Which leads to:
+
+```
+/tmp/crate2/
+|-- ro-crate-metadata.json
+`-- test-data
+    |-- sample_file.txt
+    `-- test_file_galaxy.txt
+```
 
 Another way to read a detached crate is to pass a JSON dictionary with the RO-Crate metadata directly to `ROCrate`. For instance:
 

--- a/README.md
+++ b/README.md
@@ -308,19 +308,19 @@ crate = ROCrate(root_dataset_id=url)
 
 In detached crates, _all_ data entities must be web-based, i.e., have an absolute URI as `@id`:
 
-```
+```python
 f1 = crate.add_file(f"{url}f1")
 ```
 
 The [recommended way](https://www.researchobject.org/ro-crate/specification/1.2/structure.html#types-of-ro-crate) to store a detached crate on disk is to write a single metadata file called `${prefix}-ro-crate-metadata.json`:
 
-```
+```python
 crate.write_detached("/tmp/example-ro-crate-metadata.json")
 ```
 
 One of the ways to consume a detached crate is to read the metadata from a local file:
 
-```
+```python
 rcrate = ROCrate("/tmp/example-ro-crate-metadata.json")
 rf1 = rcrate.dereference(f"{url}f1")
 ```
@@ -358,7 +358,7 @@ rcrate.write("/tmp/crate")
 
 This leads to the following structure on the file system:
 
-```python
+```
 /tmp/crate/
 |-- ro-crate-metadata.json
 |-- sample_file.txt

--- a/README.md
+++ b/README.md
@@ -341,47 +341,6 @@ sample_file = read_crate.dereference(f"{base}sample_file.txt")
 test_file_galaxy = read_crate.dereference(f"{base}test_file_galaxy.txt")
 ```
 
-Suppose you now want to save the crate to the local file system. You could use `write_detached` as shown above:
-
-```python
-read_crate.write_detached("/tmp/detached-ro-crate-metadata.json")
-```
-
-but you could also write the crate as attached, after tweaking the data entities a bit:
-
-```python
-sample_file.fetch_remote = True
-test_file_galaxy.fetch_remote = True
-read_crate.write("/tmp/crate")
-```
-
-This leads to the following structure on the file system:
-
-```
-/tmp/crate/
-|-- ro-crate-metadata.json
-|-- sample_file.txt
-`-- test-data
-    `-- test_file_galaxy.txt
-```
-
-Note that `test_file_galaxy` was written as `test-data/test-file-galaxy.txt` relative to the crate root: this is due to the fact that the original crate specifies `"localPath": "test-data/test-file-galaxy.txt"`. In contrast, `localPath` is not specified for the other file, so the library applies the default behavior of using the basename as the relative path. This can be changed by setting `localPath` on the file entity:
-
-```python
-sample_file["localPath"] = "test-data/sample_file.txt"
-read_crate.write("/tmp/crate2")
-```
-
-Which leads to:
-
-```
-/tmp/crate2/
-|-- ro-crate-metadata.json
-`-- test-data
-    |-- sample_file.txt
-    `-- test_file_galaxy.txt
-```
-
 Another way to read a detached crate is to pass a JSON dictionary with the RO-Crate metadata directly to `ROCrate`. For instance:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -309,42 +309,42 @@ crate = ROCrate(root_dataset_id=url)
 In detached crates, _all_ data entities must be web-based, i.e., have an absolute URI as `@id`:
 
 ```python
-f1 = crate.add_file(f"{url}f1")
+file_1 = crate.add_file(f"{url}file_1")  # http://example.com/crate/file_1
 ```
 
-The [recommended way](https://www.researchobject.org/ro-crate/specification/1.2/structure.html#types-of-ro-crate) to store a detached crate on disk is to write a single metadata file called `${prefix}-ro-crate-metadata.json`:
+The [recommended way](https://www.researchobject.org/ro-crate/specification/1.2/structure.html#types-of-ro-crate) to store a detached crate on disk is to write a single metadata file called `${prefix}-ro-crate-metadata.json`, where `${prefix}` is a variable. The library supports this through the `write_detached` method, which takes as argument an arbitrary path (a warning will be issued if the path does not follow the above pattern):
 
 ```python
 crate.write_detached("/tmp/example-ro-crate-metadata.json")
 ```
 
-One of the ways to consume a detached crate is to read the metadata from a local file:
+One of the ways to consume a detached crate is to read the metadata from a local file. For instance, to read the crate that we just wrote:
 
 ```python
-rcrate = ROCrate("/tmp/example-ro-crate-metadata.json")
-rf1 = rcrate.dereference(f"{url}f1")
+read_crate = ROCrate("/tmp/example-ro-crate-metadata.json")
+read_file_1 = read_crate.dereference(f"{url}file_1")
 ```
 
 This also works with a local `file://` URI:
 
 ```python
-rcrate = ROCrate("file:///tmp/example-ro-crate-metadata.json")
+read_crate = ROCrate("file:///tmp/example-ro-crate-metadata.json")
 ```
 
 and with a remote URI:
 
 ```python
 base = "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/"
-rcrate = ROCrate(f"{base}detached-ro-crate-metadata.json")
-assert rcrate.root_dataset.id == base
-sample_file = rcrate.dereference(f"{base}sample_file.txt")
-test_file_galaxy = rcrate.dereference(f"{base}test_file_galaxy.txt")
+read_crate = ROCrate(f"{base}detached-ro-crate-metadata.json")
+assert read_crate.root_dataset.id == base
+sample_file = read_crate.dereference(f"{base}sample_file.txt")
+test_file_galaxy = read_crate.dereference(f"{base}test_file_galaxy.txt")
 ```
 
 Suppose you now want to save the crate to the local file system. You could use `write_detached` as shown above:
 
 ```python
-rcrate.write_detached("/tmp/detached-ro-crate-metadata.json")
+read_crate.write_detached("/tmp/detached-ro-crate-metadata.json")
 ```
 
 but you could also write the crate as attached, after tweaking the data entities a bit:
@@ -353,7 +353,7 @@ but you could also write the crate as attached, after tweaking the data entities
 sample_file.fetch_remote = True
 sample_file["localPath"] = "sample_file.txt"
 test_file_galaxy.fetch_remote = True
-rcrate.write("/tmp/crate")
+read_crate.write("/tmp/crate")
 ```
 
 This leads to the following structure on the file system:

--- a/README.md
+++ b/README.md
@@ -293,6 +293,95 @@ article = crate.dereference("paper.pdf")
 
 ## Advanced features
 
+### Detached crates
+
+[RO-Crate 1.2](https://www.researchobject.org/ro-crate/whats-changed-in-1-2) introduces the concept of _detached_ RO-Crates, which have no defined root directory: in detached crates, the metadata is accessed independently, for instance via an API or from a standalone metadata file. By contrast, "traditional" crates that describe a payload of files and directories contained in a root directory are called _attached_.
+
+Both detached and attached crates can have a root data entity with an absolute URI as `@id`. To create an RO-Crate whose root data entity `@id` is different from the default `./`, use the `root_dataset_id` argument in the constructor:
+
+```python
+from rocrate.rocrate import ROCrate
+
+url = "http://example.com/crate/"
+crate = ROCrate(root_dataset_id=url)
+```
+
+In detached crates, _all_ data entities must be web-based, i.e., have an absolute URI as `@id`:
+
+```
+f1 = crate.add_file(f"{url}f1")
+```
+
+The [recommended way](https://www.researchobject.org/ro-crate/specification/1.2/structure.html#types-of-ro-crate) to store a detached crate on disk is to write a single metadata file called `${prefix}-ro-crate-metadata.json`:
+
+```
+crate.write_detached("/tmp/example-ro-crate-metadata.json")
+```
+
+One of the ways to consume a detached crate is to read the metadata from a local file:
+
+```
+rcrate = ROCrate("/tmp/example-ro-crate-metadata.json")
+rf1 = rcrate.dereference(f"{url}f1")
+```
+
+This also works with a local `file://` URI:
+
+```python
+rcrate = ROCrate("file:///tmp/example-ro-crate-metadata.json")
+```
+
+and with a remote URI:
+
+```python
+base = "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/"
+rcrate = ROCrate(f"{base}detached-ro-crate-metadata.json")
+assert rcrate.root_dataset.id == base
+sample_file = rcrate.dereference(f"{base}sample_file.txt")
+test_file_galaxy = rcrate.dereference(f"{base}test_file_galaxy.txt")
+```
+
+Suppose you now want to save the crate to the local file system. You could use `write_detached` as shown above:
+
+```python
+rcrate.write_detached("/tmp/detached-ro-crate-metadata.json")
+```
+
+but you could also write the crate as attached, after tweaking the data entities a bit:
+
+```python
+sample_file.fetch_remote = True
+sample_file["localPath"] = "sample_file.txt"
+test_file_galaxy.fetch_remote = True
+rcrate.write("/tmp/crate")
+```
+
+This leads to the following structure on the file system:
+
+```python
+/tmp/crate/
+|-- ro-crate-metadata.json
+|-- sample_file.txt
+`-- test-data
+    `-- test_file_galaxy.txt
+```
+
+Note that we did not have to set `localPath` for `test_file_galaxy` because it was already set in the original crate that we read from the remote url.
+
+Another way to read a detached crate is to pass a JSON dictionary with the RO-Crate metadata directly to `ROCrate`. For instance:
+
+```python
+import json
+from rocrate.rocrate import ROCrate
+
+with open("/tmp/example-ro-crate-metadata.json") as f:
+    metadata = json.load(f)
+crate = ROCrate(metadata)
+```
+
+In the above example we read the metadata from a local file, but you could get it from an API endpoint or any other source.
+
+
 ### Subcrates
 
 An RO-Crate can contain one or more nested RO-Crates. For instance, consider the following layout:

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -21,8 +21,19 @@
 # limitations under the License.
 
 import json
+import re
+import warnings
+
+import requests
 
 from .model.metadata import BASENAME, LEGACY_BASENAME
+from .utils import is_url
+
+# https://www.researchobject.org/ro-crate/specification/1.2/structure
+#   "If stored in a file... the filename SHOULD be..."
+# https://www.researchobject.org/ro-crate/specification/1.2/data-entities
+#   "It is NOT RECOMMENDED to resolve a relative root identifier..."
+MD_PATTERN = re.compile(r".*[/-]ro-crate-metadata.json(ld)?$")
 
 
 def read_metadata(metadata_path):
@@ -34,6 +45,15 @@ def read_metadata(metadata_path):
     """
     if isinstance(metadata_path, dict):
         metadata = metadata_path
+    elif is_url(str(metadata_path)):
+        if not MD_PATTERN.match(metadata_path):
+            warnings.warn(f"URI {metadata_path} should follow the pattern {MD_PATTERN.pattern!r}")
+        resp = requests.get(metadata_path)
+        resp.raise_for_status()
+        content_type = resp.headers.get("Content-Type", "")
+        if "application/json" not in content_type.lower():
+            warnings.warn(f"URI {metadata_path} does not have a JSON content type")
+        metadata = resp.json()
     else:
         with open(metadata_path, 'r', encoding='utf-8') as f:
             metadata = json.load(f)

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -23,6 +23,7 @@
 import json
 import re
 import warnings
+import urllib.request
 
 import requests
 
@@ -48,12 +49,16 @@ def read_metadata(metadata_path):
     elif is_url(str(metadata_path)):
         if not MD_PATTERN.match(metadata_path):
             warnings.warn(f"URI {metadata_path} should follow the pattern {MD_PATTERN.pattern!r}")
-        resp = requests.get(metadata_path)
-        resp.raise_for_status()
-        content_type = resp.headers.get("Content-Type", "")
-        if "application/json" not in content_type.lower():
-            warnings.warn(f"URI {metadata_path} does not have a JSON content type")
-        metadata = resp.json()
+        if metadata_path.startswith("file:"):
+            with urllib.request.urlopen(metadata_path) as resp:
+                metadata = json.load(resp)
+        else:
+            with requests.get(metadata_path) as resp:
+                resp.raise_for_status()
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" not in content_type.lower():
+                    warnings.warn(f"URI {metadata_path} does not have a JSON content type")
+                metadata = resp.json()
     else:
         with open(metadata_path, 'r', encoding='utf-8') as f:
             metadata = json.load(f)

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -55,9 +55,6 @@ def read_metadata(metadata_path):
         else:
             with requests.get(metadata_path) as resp:
                 resp.raise_for_status()
-                content_type = resp.headers.get("Content-Type", "")
-                if "application/json" not in content_type.lower():
-                    warnings.warn(f"URI {metadata_path} does not have a JSON content type")
                 metadata = resp.json()
     else:
         with open(metadata_path, 'r', encoding='utf-8') as f:

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -121,17 +121,23 @@ class Dataset(FileOrDir):
                 with urlopen(self.source) as _:
                     self._jsonld['sdDatePublished'] = iso_now()
         else:
-            base = self.source.rstrip("/")
+            relative_dest_uri = self.get("localPath") or self.id
+            if is_url(relative_dest_uri):
+                if relative_dest_uri.startswith(self.crate.root_dataset.id):
+                    relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]
+                else:
+                    relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
+                self["localPath"] = relative_dest_uri
+            out_dir_path = Path(unquote(relative_dest_uri))
+
             for entry in self._jsonld.get("hasPart", []):
                 try:
                     part = entry["@id"]
-                    if is_url(part) or part.startswith("/"):
-                        raise RuntimeError(f"'{self.source}': part '{part}' is not a relative path")
-                    part_uri = f"{base}/{part}"
-                    rel_out_path = Path(self.id) / part
-
+                    if not is_url(part):
+                        raise RuntimeError(f"'{self.source}' is a URL, but part '{part}' is not a URL")
+                    rel_out_path = out_dir_path / part.rsplit("/", 1)[-1]
                     is_empty = True
-                    with urlopen(part_uri) as response:
+                    with urlopen(part) as response:
                         while chunk := response.read(chunk_size):
                             is_empty = False
                             yield str(rel_out_path), chunk

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -31,7 +31,7 @@ from urllib.request import urlopen
 from urllib.parse import unquote
 
 from .file_or_dir import FileOrDir
-from ..utils import is_url, iso_now, Mode
+from ..utils import as_list, is_url, iso_now, Mode
 
 
 class Dataset(FileOrDir):
@@ -140,6 +140,11 @@ class Dataset(FileOrDir):
                     if not is_url(part):
                         raise RuntimeError(f"'{self.source}' is a URL, but part '{part}' is not a URL")
                     rel_out_path = out_dir_path / part.rsplit("/", 1)[-1]
+                    # override with file localPath if set
+                    if part_file := self.crate.get(part):
+                        if "File" in as_list(part_file.type):
+                            if file_local_path := part_file.get("localPath"):
+                                rel_out_path = file_local_path
                     is_empty = True
                     with urlopen(part) as response:
                         while chunk := response.read(chunk_size):

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -122,7 +122,10 @@ class Dataset(FileOrDir):
                 with urlopen(self.source) as _:
                     self._jsonld['sdDatePublished'] = iso_now()
         else:
-            relative_dest_uri = self.get("localPath") or self.id
+            if is_url(self.id):
+                relative_dest_uri = self.get("localPath") or self.id
+            else:
+                relative_dest_uri = self.id
             if is_url(relative_dest_uri):
                 if relative_dest_uri.startswith(self.crate.root_dataset.id):
                     relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -131,7 +131,6 @@ class Dataset(FileOrDir):
                     relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]
                 else:
                     relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
-                self["localPath"] = relative_dest_uri
             out_dir_path = Path(unquote(relative_dest_uri))
 
             for entry in self._jsonld.get("hasPart", []):

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -140,10 +140,12 @@ class Dataset(FileOrDir):
                     if not is_url(part):
                         raise RuntimeError(f"'{self.source}' is a URL, but part '{part}' is not a URL")
                     rel_out_path = out_dir_path / part.rsplit("/", 1)[-1]
-                    # override with file localPath if set
-                    if part_file := self.crate.get(part):
-                        if "File" in as_list(part_file.type):
-                            if file_local_path := part_file.get("localPath"):
+                    if part_entity := self.crate.get(part):
+                        if "Dataset" in as_list(part_entity.type):
+                            continue
+                        # override with file localPath if set
+                        if "File" in as_list(part_entity.type):
+                            if file_local_path := part_entity.get("localPath"):
                                 rel_out_path = file_local_path
                     is_empty = True
                     with urlopen(part) as response:

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -71,13 +71,16 @@ class File(FileOrDir):
             self._jsonld['contentSize'] = str(out_file_path.stat().st_size)
 
     def write(self, base_path):
-        relative_dest_uri = self.get("localPath") or self.id
-        if self.fetch_remote and is_url(relative_dest_uri):
-            if relative_dest_uri.startswith(self.crate.root_dataset.id):
-                relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]
-            else:
-                relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
-            self["localPath"] = relative_dest_uri
+        if self.fetch_remote and is_url(str(self.source)):
+            relative_dest_uri = self.get("localPath") or self.id
+            if is_url(relative_dest_uri):
+                if relative_dest_uri.startswith(self.crate.root_dataset.id):
+                    relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]
+                else:
+                    relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
+                self["localPath"] = relative_dest_uri
+        else:
+            relative_dest_uri = self.id
         out_file_path = Path(base_path) / unquote(relative_dest_uri)
         if isinstance(self.source, (BytesIO, StringIO)) or is_url(str(self.source)):
             self._write_from_stream(out_file_path)

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -74,6 +74,7 @@ class File(FileOrDir):
         relative_dest_uri = self.get("localPath") or self.id
         if self.fetch_remote and is_url(relative_dest_uri):
             relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
+            self["localPath"] = relative_dest_uri
         out_file_path = Path(base_path) / unquote(relative_dest_uri)
         if isinstance(self.source, (BytesIO, StringIO)) or is_url(str(self.source)):
             self._write_from_stream(out_file_path)

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -71,8 +71,10 @@ class File(FileOrDir):
             self._jsonld['contentSize'] = str(out_file_path.stat().st_size)
 
     def write(self, base_path):
-        local_path = self.get("localPath")
-        out_file_path = Path(base_path) / unquote(local_path or self.id)
+        relative_dest_uri = self.get("localPath") or self.id
+        if self.fetch_remote and is_url(relative_dest_uri):
+            relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
+        out_file_path = Path(base_path) / unquote(relative_dest_uri)
         if isinstance(self.source, (BytesIO, StringIO)) or is_url(str(self.source)):
             self._write_from_stream(out_file_path)
         elif self.source is None:

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -73,7 +73,10 @@ class File(FileOrDir):
 
     def write(self, base_path):
         if self.fetch_remote and is_url(str(self.source)):
-            relative_dest_uri = self.get("localPath") or self.id
+            if is_url(self.id):
+                relative_dest_uri = self.get("localPath") or self.id
+            else:
+                relative_dest_uri = self.id
             if is_url(relative_dest_uri):
                 if relative_dest_uri.startswith(self.crate.root_dataset.id):
                     relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -82,7 +82,6 @@ class File(FileOrDir):
                     relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]
                 else:
                     relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
-                self["localPath"] = relative_dest_uri
         else:
             relative_dest_uri = self.id
         out_file_path = Path(base_path) / unquote(relative_dest_uri)

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -71,7 +71,8 @@ class File(FileOrDir):
             self._jsonld['contentSize'] = str(out_file_path.stat().st_size)
 
     def write(self, base_path):
-        out_file_path = Path(base_path) / unquote(self.id)
+        local_path = self.get("localPath")
+        out_file_path = Path(base_path) / unquote(local_path or self.id)
         if isinstance(self.source, (BytesIO, StringIO)) or is_url(str(self.source)):
             self._write_from_stream(out_file_path)
         elif self.source is None:

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -73,7 +73,10 @@ class File(FileOrDir):
     def write(self, base_path):
         relative_dest_uri = self.get("localPath") or self.id
         if self.fetch_remote and is_url(relative_dest_uri):
-            relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
+            if relative_dest_uri.startswith(self.crate.root_dataset.id):
+                relative_dest_uri = relative_dest_uri[len(self.crate.root_dataset.id):]
+            else:
+                relative_dest_uri = relative_dest_uri.rsplit("/", 1)[-1]
             self["localPath"] = relative_dest_uri
         out_file_path = Path(base_path) / unquote(relative_dest_uri)
         if isinstance(self.source, (BytesIO, StringIO)) or is_url(str(self.source)):

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -94,7 +94,7 @@ class Metadata(File):
         return True
 
     def write(self, dest_base):
-        write_path = Path(dest_base) / self.id
+        write_path = Path(dest_base) / self.id.rsplit("/", 1)[-1]
         super()._write_from_stream(write_path)
 
     @property

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -24,6 +24,8 @@
 
 import json
 from pathlib import Path
+import re
+import warnings
 
 from .file import File
 from .dataset import Dataset
@@ -37,6 +39,7 @@ SUPPORTED_VERSIONS = {
 DEFAULT_VERSION = "1.2"
 BASENAME = "ro-crate-metadata.json"
 LEGACY_BASENAME = "ro-crate-metadata.jsonld"
+DETACHED_MD_NAME = re.compile(r".*-ro-crate-metadata.json$")
 
 WORKFLOW_PROFILE = "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
 
@@ -96,6 +99,12 @@ class Metadata(File):
     def write(self, dest_base):
         write_path = Path(dest_base) / self.id.rsplit("/", 1)[-1]
         super()._write_from_stream(write_path)
+
+    def write_detached(self, path):
+        if not DETACHED_MD_NAME.match(str(path)):
+            warnings.warn(f"{path} should follow the pattern {DETACHED_MD_NAME.pattern!r}")
+        path = Path(path)
+        super()._write_from_stream(path)
 
     @property
     def root(self) -> Dataset:

--- a/rocrate/model/preview.py
+++ b/rocrate/model/preview.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from jinja2 import Template
 from .file import File
+from ..utils import is_url
 
 
 class Preview(File):
@@ -98,6 +99,8 @@ class Preview(File):
             yield self.id, str.encode(self.generate_html(), encoding='utf-8')
 
     def _has_writeable_stream(self):
+        if is_url(str(self.source)):
+            return self.fetch_remote
         return True
 
     def write(self, dest_base):

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -123,7 +123,8 @@ class ROCrate():
                  gen_preview=False,
                  init=False, exclude=None,
                  version=DEFAULT_VERSION,
-                 load_subcrates=False):
+                 load_subcrates=False,
+                 root_dataset_id=None):
         self.mode = None
         self.source = source
         self.exclude = exclude
@@ -138,7 +139,12 @@ class ROCrate():
             self.add(Preview(self))
         if not source:
             self.mode = Mode.CREATE
-            self.add(RootDataset(self), Metadata(self, version=version))
+            if root_dataset_id is not None:
+                if root_dataset_id != "./" and not is_url(root_dataset_id):
+                    raise ValueError("the root dataset id must be either ./ or an absolute URI")
+            rde = RootDataset(self, root_dataset_id)
+            md = Metadata(self, properties={"about": rde}, version=version)
+            self.add(rde, md)
         elif init:
             self.mode = Mode.INIT
             if isinstance(source, dict):

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -945,7 +945,11 @@ class Subcrate(Dataset):
         """
         if self._crate is None:
             # load_subcrates=True to load further nested RO-Crate (on-demand / lazily too)
-            self._crate = ROCrate(self.source, load_subcrates=True)
+            if subject_of := self.get("subjectOf"):
+                subcrate_uri = subject_of.id if isinstance(subject_of, Entity) else subject_of
+                self._crate = ROCrate(subcrate_uri, load_subcrates=True)
+            else:
+                self._crate = ROCrate(self.source, load_subcrates=True)
 
     def write(self, base_path):
         super().write(base_path)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -176,7 +176,7 @@ class ROCrate():
                     self.add(Preview(self, source))
 
     def __read(self, source, gen_preview=False):
-        if isinstance(source, dict):
+        if isinstance(source, dict) or is_url(str(source)):
             metadata_path = source
         else:
             source = Path(source)
@@ -201,6 +201,8 @@ class ROCrate():
     def __read_data_entities(self, entities, source, gen_preview):
         if isinstance(source, dict):
             source = Path("")
+        elif is_url(str(source)):
+            source = source.rsplit("/", 1)[0] + "/"
         metadata_id, root_id = find_root_entity_id(entities)
         root_entity = entities.pop(root_id)
         assert root_id == root_entity.pop('@id')
@@ -212,7 +214,8 @@ class ROCrate():
 
         preview_entity = entities.pop(Preview.BASENAME, None)
         if preview_entity and not gen_preview:
-            self.add(Preview(self, source / Preview.BASENAME, properties=preview_entity))
+            preview_source = source + Preview.BASENAME if is_url(str(source)) else source / Preview.BASENAME
+            self.add(Preview(self, preview_source, properties=preview_entity))
         self.__add_parts(parts, entities, source)
 
     def __add_parts(self, parts, entities, source):
@@ -240,6 +243,8 @@ class ROCrate():
 
                 if is_url(id_):
                     instance = Subcrate(self, source=id_, properties=entity)
+                elif is_url(str(source)):
+                    instance = Subcrate(self, source + id_, id_, properties=entity)
                 else:
                     instance = Subcrate(self, source=source / unquote(id_), properties=entity)
 
@@ -250,6 +255,8 @@ class ROCrate():
                 # cls is either a File or a Dataset (Directory)
                 if is_url(id_):
                     instance = cls(self, id_, properties=entity)
+                elif is_url(str(source)):
+                    instance = cls(self, source + id_, id_, properties=entity)
                 else:
                     instance = cls(self, source / unquote(id_), id_, properties=entity)
             self.add(instance)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -188,11 +188,14 @@ class ROCrate():
                 with zipfile.ZipFile(source, "r") as zf:
                     zf.extractall(zip_path)
                 source = Path(zip_path)
-            metadata_path = source / BASENAME
-            if not metadata_path.is_file():
-                metadata_path = source / LEGACY_BASENAME
-            if not metadata_path.is_file():
-                raise ValueError(f"Not a valid RO-Crate: missing {BASENAME}")
+            if source.is_file():
+                metadata_path = source
+            else:
+                metadata_path = source / BASENAME
+                if not metadata_path.is_file():
+                    metadata_path = source / LEGACY_BASENAME
+                if not metadata_path.is_file():
+                    raise ValueError(f"Not a valid RO-Crate: missing {BASENAME}")
         _, entities = read_metadata(metadata_path)
         self.__read_data_entities(entities, source, gen_preview)
         self.__read_contextual_entities(entities)
@@ -214,7 +217,12 @@ class ROCrate():
 
         preview_entity = entities.pop(Preview.BASENAME, None)
         if preview_entity and not gen_preview:
-            preview_source = source + Preview.BASENAME if is_url(str(source)) else source / Preview.BASENAME
+            if is_url(str(source)):
+                preview_source = source + Preview.BASENAME
+            elif source.is_file():
+                preview_source = source.parent / Preview.BASENAME
+            else:
+                preview_source = source / Preview.BASENAME
             self.add(Preview(self, preview_source, properties=preview_entity))
         self.__add_parts(parts, entities, source)
 
@@ -245,6 +253,8 @@ class ROCrate():
                     instance = Subcrate(self, source=id_, properties=entity)
                 elif is_url(str(source)):
                     instance = Subcrate(self, source + id_, id_, properties=entity)
+                elif source.is_file():
+                    instance = Subcrate(self, source.parent / unquote(id_), id_, properties=entity)
                 else:
                     instance = Subcrate(self, source=source / unquote(id_), properties=entity)
 
@@ -257,6 +267,8 @@ class ROCrate():
                     instance = cls(self, id_, properties=entity)
                 elif is_url(str(source)):
                     instance = cls(self, source + id_, id_, properties=entity)
+                elif source.is_file():
+                    instance = cls(self, source.parent / unquote(id_), id_, properties=entity)
                 else:
                     instance = cls(self, source / unquote(id_), id_, properties=entity)
             self.add(instance)
@@ -601,7 +613,7 @@ class ROCrate():
     def write(self, base_path):
         base_path = Path(base_path)
         base_path.mkdir(parents=True, exist_ok=True)
-        if self.source and not isinstance(self.source, dict):
+        if self.source and not isinstance(self.source, dict) and Path(self.source).is_dir():
             self._copy_unlisted(self.source, base_path)
         for writable_entity in self.data_entities + self.default_entities:
             writable_entity.write(base_path)

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -627,6 +627,9 @@ class ROCrate():
                 f.write(chunk)
         return out_path
 
+    def write_detached(self, metadata_path):
+        self.metadata.write_detached(metadata_path)
+
     def stream_zip(self, chunk_size=8192):
         """ Create a stream of bytes representing the RO-Crate as a ZIP file. """
         yield from self._stream_zip(chunk_size=chunk_size)

--- a/test/test-data/detached-ro-crate-metadata.json
+++ b/test/test-data/detached-ro-crate-metadata.json
@@ -26,6 +26,12 @@
                 },
                 {
                     "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/test_file_galaxy.txt"
+                },
+                {
+                    "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/read_extra/listed.txt"
+                },
+                {
+                    "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test_read.py"
                 }
             ]
         },
@@ -39,6 +45,14 @@
             "@type": "File",
             "name": "Test data",
             "localPath": "test-data/test_file_galaxy.txt"
+        },
+        {
+            "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/read_extra/listed.txt",
+            "@type": "File"
+        },
+        {
+            "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test_read.py",
+            "@type": "File"
         },
         {
             "@id": "http://spdx.org/licenses/CC0-1.0",

--- a/test/test-data/detached_crate_with_subcrates/subcrates-ro-crate-metadata.json
+++ b/test/test-data/detached_crate_with_subcrates/subcrates-ro-crate-metadata.json
@@ -1,0 +1,51 @@
+{
+    "@context": "https://w3id.org/ro/crate/1.2/context",
+    "@graph": [
+        {
+            "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/detached_crate_with_subcrates/",
+            "@type": "Dataset",
+            "name": "Detached crate with subcrates",
+            "description": "A detached RO-Crate that references other crates",
+            "license": "https://spdx.org/licenses/MIT.html",
+            "datePublished": "2026-02-06",
+            "hasPart": [
+                {
+                    "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/sample_file.txt"
+                },
+                {
+                    "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/"
+                }
+            ]
+        },
+        {
+            "@id": "ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "about": {
+                "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/detached_crate_with_subcrates/"
+            },
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.2"
+            }
+        },
+        {
+            "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/sample_file.txt",
+            "@type": "File"
+        },
+        {
+            "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/",
+            "@type": "Dataset",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate"
+            },
+            "subjectOf": {
+                "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/detached-ro-crate-metadata.json"
+            }
+        },
+        {
+            "@id": "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/detached-ro-crate-metadata.json",
+            "@type": "CreativeWork",
+            "encodingFormat": "application/ld+json",
+            "sdDatePublished": "2026-02-06"
+        }
+    ]
+}

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -706,7 +706,10 @@ def test_detached(tmpdir):
             },
         ]
     }
+
     crate = ROCrate(metadata)
+    assert crate.root_dataset.id == base_uri
+    assert crate.metadata.id == f"{base_uri}ro-crate-metadata.json"
     d1 = crate.dereference(f"{base_uri}d1")
     assert d1
     d2 = crate.dereference(f"{base_uri}d1/d2")
@@ -720,7 +723,10 @@ def test_detached(tmpdir):
     out_path = tmpdir / 'out_crate'
     crate.write(out_path)
     assert (out_path / "ro-crate-metadata.json").is_file()
+
     crate = ROCrate(out_path)
+    assert crate.root_dataset.id == base_uri
+    assert crate.metadata.id == f"{base_uri}ro-crate-metadata.json"
     d1 = crate.dereference(f"{base_uri}d1")
     assert d1
     d2 = crate.dereference(f"{base_uri}d1/d2")

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -674,7 +674,7 @@ def test_detached(tmpdir):
         "@context": "https://w3id.org/ro/crate/1.2/context",
         "@graph": [
             {
-                "@id": f"{base_uri}ro-crate-metadata.json",
+                "@id": "ro-crate-metadata.json",
                 "@type": "CreativeWork",
                 "about": {"@id": base_uri},
                 "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"}
@@ -709,7 +709,7 @@ def test_detached(tmpdir):
 
     crate = ROCrate(metadata)
     assert crate.root_dataset.id == base_uri
-    assert crate.metadata.id == f"{base_uri}ro-crate-metadata.json"
+    assert crate.metadata.id == "ro-crate-metadata.json"
     d1 = crate.dereference(f"{base_uri}d1")
     assert d1
     d2 = crate.dereference(f"{base_uri}d1/d2")
@@ -720,13 +720,14 @@ def test_detached(tmpdir):
     assert p
     assert set(crate.data_entities) == {d1, d2, f1}
     assert set(crate.contextual_entities) == {p}
+
     out_path = tmpdir / 'out_crate'
     crate.write(out_path)
     assert (out_path / "ro-crate-metadata.json").is_file()
 
     crate = ROCrate(out_path)
     assert crate.root_dataset.id == base_uri
-    assert crate.metadata.id == f"{base_uri}ro-crate-metadata.json"
+    assert crate.metadata.id == "ro-crate-metadata.json"
     d1 = crate.dereference(f"{base_uri}d1")
     assert d1
     d2 = crate.dereference(f"{base_uri}d1/d2")

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -32,6 +32,7 @@ from rocrate.model import DataEntity, ContextEntity, File, Dataset
 
 _URL = ('https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/'
         'test/test-data/sample_file.txt')
+THIS_DIR = Path(__file__).absolute().parent
 
 
 @pytest.mark.parametrize("gen_preview,from_zip", [(False, False), (True, False), (True, True)])
@@ -908,11 +909,13 @@ def test_not_data_entity_linked(version):
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_from_uri(tmpdir):
-    source = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
-              "master/test/test-data/read_crate/ro-crate-metadata.json")
-    base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
-                "master/test/test-data/read_crate/")
+@pytest.mark.parametrize("source_base", [
+    "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
+    f"file://{THIS_DIR}/"
+])
+def test_from_uri(tmpdir, source_base):
+    source = f"{source_base}test-data/read_crate/ro-crate-metadata.json"
+    base_uri = f"{source_base}test-data/read_crate/"
     # this is an absolute URI in the metadata, note it's outside the crate
     remote_f_uri = ("https://raw.githubusercontent.com/ResearchObject/"
                     "ro-crate-py/master/test/test-data/sample_file.txt")
@@ -964,9 +967,12 @@ def test_from_uri(tmpdir):
 
 
 @pytest.mark.filterwarnings("ignore")
-def test_from_uri_detached(tmpdir):
-    source = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
-              "master/test/test-data/detached-ro-crate-metadata.json")
+@pytest.mark.parametrize("source_base", [
+    "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
+    f"file://{THIS_DIR}/"
+])
+def test_from_uri_detached(tmpdir, source_base):
+    source = f"{source_base}test-data/detached-ro-crate-metadata.json"
     base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
                 "master/test/test-data/")
     crate = ROCrate(source)

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1142,3 +1142,52 @@ def test_read_remote_dir(tmpdir):
     assert (out_path / "ro-crate-metadata.json").is_file()
     assert (out_path / "misc" / "errorpages" / "404.html").is_file()
     assert (out_path / "misc" / "errorpages" / "500.html").is_file()
+
+
+def test_read_remote_dir_local_path(tmpdir):
+    base_uri = "https://ftp.mozilla.org/pub/"
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "about": {"@id": base_uri},
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"}
+            },
+            {
+                "@id": base_uri,
+                "@type": "Dataset",
+                "datePublished": "2026-02-19",
+                "hasPart": [{"@id": f"{base_uri}misc/errorpages/"}]
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/",
+                "@type": "Dataset",
+                "localPath": "errorpages/",
+                "hasPart": [
+                    {"@id": f"{base_uri}misc/errorpages/404.html"},
+                    {"@id": f"{base_uri}misc/errorpages/500.html"}
+                ]
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/404.html",
+                "@type": "File"
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/500.html",
+                "@type": "File",
+                "localPath": "errorpages/500/500.html"
+            }
+        ]
+    }
+    crate = ROCrate(metadata)
+    errorpages = crate.get(f"{base_uri}misc/errorpages/")
+    errorpages.fetch_remote = True
+    out_path = tmpdir / 'out_crate'
+    crate.write(out_path)
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    assert not (out_path / "misc").exists()
+    assert (out_path / "errorpages" / "404.html").is_file()
+    assert not (out_path / "errorpages" / "500.html").exists()
+    assert (out_path / "errorpages" / "500" / "500.html").is_file()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1096,3 +1096,48 @@ def test_from_file_detached(test_data_dir, tmpdir):
     assert (out_path / "test-data" / "test_file_galaxy.txt").is_file()
     assert (out_path / "read_extra" / "listed.txt").is_file()
     assert (out_path / "test_read.py").is_file()
+
+
+def test_read_remote_dir(tmpdir):
+    base_uri = "https://ftp.mozilla.org/pub/"
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "about": {"@id": base_uri},
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"}
+            },
+            {
+                "@id": base_uri,
+                "@type": "Dataset",
+                "datePublished": "2026-02-19",
+                "hasPart": [{"@id": f"{base_uri}misc/errorpages/"}]
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/",
+                "@type": "Dataset",
+                "hasPart": [
+                    {"@id": f"{base_uri}misc/errorpages/404.html"},
+                    {"@id": f"{base_uri}misc/errorpages/500.html"}
+                ]
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/404.html",
+                "@type": "File"
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/500.html",
+                "@type": "File"
+            }
+        ]
+    }
+    crate = ROCrate(metadata)
+    errorpages = crate.get(f"{base_uri}misc/errorpages/")
+    errorpages.fetch_remote = True
+    out_path = tmpdir / 'out_crate'
+    crate.write(out_path)
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    assert (out_path / "misc" / "errorpages" / "404.html").is_file()
+    assert (out_path / "misc" / "errorpages" / "500.html").is_file()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -960,6 +960,22 @@ def test_from_uri(tmpdir, source_base):
     assert rcrate.preview.id == "ro-crate-preview.html"
     assert rcrate.get(test_fn)
     assert rcrate.get(remote_f_uri)
+
+
+@pytest.mark.parametrize("source_base", [
+    "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
+    f"file:///{THIS_DIR}/"  # extra slash needed on some windows systems
+])
+def test_from_uri_fetch_remote(tmpdir, source_base):
+    source = f"{source_base}test-data/read_crate/ro-crate-metadata.json"
+    base_uri = f"{source_base}test-data/read_crate/"
+    # this is an absolute URI in the metadata, note it's outside the crate
+    remote_f_uri = ("https://raw.githubusercontent.com/ResearchObject/"
+                    "ro-crate-py/master/test/test-data/sample_file.txt")
+    test_fn = "test_file_galaxy.txt"
+    crate = ROCrate(source)
+    remote_f = crate.get(remote_f_uri)
+    test_f = crate.get(test_fn)
     # now set some fetch_remote to True
     crate.preview.fetch_remote = True
     test_f.fetch_remote = True
@@ -967,7 +983,7 @@ def test_from_uri(tmpdir, source_base):
     assert remote_f.id == remote_f_uri
     # remote_f.id is the full URI. Check that the destination path is
     # the output dir / remote_f.id minus the root dataset id.
-    shutil.rmtree(out_path)
+    out_path = tmpdir / "out_crate"
     crate.write(out_path)
     assert (out_path / "sample_file.txt").is_file()
     # check that localPath overrides the default destination
@@ -1015,20 +1031,31 @@ def test_from_uri_detached(tmpdir, source_base):
     rcrate = ROCrate(out_path)
     assert rcrate.get(f"{base_uri}sample_file.txt")
     assert rcrate.get(f"{base_uri}test_file_galaxy.txt")
+    license = rcrate.get("http://spdx.org/licenses/CC0-1.0")
+    assert set(rcrate.contextual_entities) == {license}
+
+
+@pytest.mark.parametrize("source_base", [
+    "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
+    f"file:///{THIS_DIR}/"  # extra slash needed on some windows systems
+])
+def test_from_uri_detached_fetch_remote(tmpdir, source_base):
+    source = f"{source_base}test-data/detached-ro-crate-metadata.json"
+    base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+                "master/test/test-data/")
+    crate = ROCrate(source)
+    test_file_galaxy = crate.get(f"{base_uri}test_file_galaxy.txt")
     # now set fetch_remote to True
     test_file_galaxy.fetch_remote = True
-    shutil.rmtree(out_path)
+    assert test_file_galaxy.get("localPath") == "test-data/test_file_galaxy.txt"
+    out_path = tmpdir / "out_crate"
     crate.write(out_path)
     assert (out_path / "test-data" / "test_file_galaxy.txt").is_file()
     rcrate = ROCrate(out_path)
-    rsample_file = rcrate.get(f"{base_uri}sample_file.txt")
-    assert rsample_file
     rtest_file_galaxy = rcrate.get(f"{base_uri}test_file_galaxy.txt")
     assert rtest_file_galaxy
     assert rtest_file_galaxy.get("contentUrl") == f"{base_uri}test_file_galaxy.txt"
     assert rtest_file_galaxy.get("localPath") == "test-data/test_file_galaxy.txt"
-    license = rcrate.get("http://spdx.org/licenses/CC0-1.0")
-    assert set(rcrate.contextual_entities) == {license}
 
 
 def test_from_file(test_data_dir, tmpdir):

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -965,7 +965,7 @@ def test_from_uri(tmpdir, source_base):
     remote_f.fetch_remote = True
     assert remote_f.id == remote_f_uri
     # remote_f.id is the full URI. Check that the destination path is
-    # automatically set to the output dir / basename upon writing.
+    # the output dir / remote_f.id minus the root dataset id.
     shutil.rmtree(out_path)
     crate.write(out_path)
     assert (out_path / "sample_file.txt").is_file()
@@ -1021,11 +1021,11 @@ def test_from_uri_detached(tmpdir, source_base):
     assert (out_path / "test-data" / "test_file_galaxy.txt").is_file()
     rcrate = ROCrate(out_path)
     rsample_file = rcrate.get(f"{base_uri}sample_file.txt")
+    assert rsample_file
     rtest_file_galaxy = rcrate.get(f"{base_uri}test_file_galaxy.txt")
     assert rtest_file_galaxy
     assert rtest_file_galaxy.get("contentUrl") == f"{base_uri}test_file_galaxy.txt"
     assert rtest_file_galaxy.get("localPath") == "test-data/test_file_galaxy.txt"
-    assert set(rcrate.data_entities) == {rsample_file, rtest_file_galaxy}
     license = rcrate.get("http://spdx.org/licenses/CC0-1.0")
     assert set(rcrate.contextual_entities) == {license}
 
@@ -1072,9 +1072,27 @@ def test_from_file_detached(test_data_dir, tmpdir):
     assert sample_file.source == f"{base_uri}sample_file.txt"
     test_file_galaxy = crate.get(f"{base_uri}test_file_galaxy.txt")
     assert test_file_galaxy.source == f"{base_uri}test_file_galaxy.txt"
+    listed = crate.get(f"{base_uri}read_extra/listed.txt")
+    assert listed.source == f"{base_uri}read_extra/listed.txt"
+    test_read_base = ("https://raw.githubusercontent.com/ResearchObject/"
+                      "ro-crate-py/master/test/")
+    test_read = crate.get(f"{test_read_base}test_read.py")
+    assert test_read.source == f"{test_read_base}test_read.py"
     out_path = tmpdir / "out_crate"
     crate.write(out_path)
     assert (out_path / "ro-crate-metadata.json").is_file()
     rcrate = ROCrate(out_path)
     assert rcrate.get(f"{base_uri}sample_file.txt")
     assert rcrate.get(f"{base_uri}test_file_galaxy.txt")
+    assert rcrate.get(f"{base_uri}read_extra/listed.txt")
+    assert rcrate.get(f"{test_read_base}test_read.py")
+
+    # set fetch_remote to True and check local paths
+    for e in crate.data_entities:
+        e.fetch_remote = True
+    shutil.rmtree(out_path)
+    crate.write(out_path)
+    assert (out_path / "sample_file.txt").is_file()
+    assert (out_path / "test-data" / "test_file_galaxy.txt").is_file()
+    assert (out_path / "read_extra" / "listed.txt").is_file()
+    assert (out_path / "test_read.py").is_file()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -963,16 +963,21 @@ def test_from_uri(tmpdir, source_base):
     crate.preview.fetch_remote = True
     test_f.fetch_remote = True
     remote_f.fetch_remote = True
-    # remote_f.id is the full URI, which by default is interpreted as a local
-    # path (with a top-level "https:" directory etc.). The id cannot be
-    # changed, so if we want the file stored in the output crate with its
-    # basename we have to set localPath, which overrides the id as destination
-    remote_f["localPath"] = "sample_file.txt"
+    assert remote_f.id == remote_f_uri
+    # remote_f.id is the full URI. Check that the destination path is
+    # automatically set to the output dir / basename upon writing.
     shutil.rmtree(out_path)
     crate.write(out_path)
+    assert (out_path / "sample_file.txt").is_file()
+    # check that localPath overrides the default destination
+    remote_f["localPath"] = "other/sample_file.txt"
+    shutil.rmtree(out_path)
+    crate.write(out_path)
+    assert (out_path / "other" / "sample_file.txt").is_file()
+    # check more paths
     assert (out_path / "ro-crate-preview.html").is_file()
     assert (out_path / test_fn).is_file()
-    assert (out_path / "sample_file.txt").is_file()
+    # read back the crate
     rcrate = ROCrate(out_path)
     assert rcrate.preview.id == "ro-crate-preview.html"
     rtest_f = rcrate.get(test_fn)
@@ -980,7 +985,7 @@ def test_from_uri(tmpdir, source_base):
     assert rtest_f.get("contentUrl") == base_uri + test_fn
     rremote_f_uri = rcrate.get(remote_f_uri)
     assert rremote_f_uri
-    assert rremote_f_uri.get("localPath") == "sample_file.txt"
+    assert rremote_f_uri.get("localPath") == "other/sample_file.txt"
 
 
 @pytest.mark.parametrize("source_base", [

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -905,3 +905,43 @@ def test_not_data_entity_linked(version):
         assert f1 in crate.contextual_entities
     else:
         assert f1 in crate.data_entities
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_from_uri(tmpdir):
+    source = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+              "master/test/test-data/read_crate/ro-crate-metadata.json")
+    base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+                "master/test/test-data/read_crate/")
+    remote_f_uri = ("https://raw.githubusercontent.com/ResearchObject/"
+                    "ro-crate-py/master/test/test-data/sample_file.txt")
+    test_fn = "test_file_galaxy.txt"
+    crate = ROCrate(source)
+    assert crate.source == source
+    assert crate.preview.source == base_uri + "ro-crate-preview.html"
+    assert crate.preview.id == "ro-crate-preview.html"
+    assert test_fn in crate
+    test_f = crate.get(test_fn)
+    assert test_f.source == base_uri + test_fn
+    remote_f = crate.get(remote_f_uri)
+    assert remote_f.source == remote_f_uri
+    assert remote_f.id == remote_f_uri
+    out_path = tmpdir / "out_crate"
+    crate.write(out_path)
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    assert not (out_path / "ro-crate-preview.html").exists()
+    assert not (out_path / test_fn).exists()
+    assert not (out_path / remote_f_uri.rsplit("/", 1)[1]).exists()
+    crate.preview.fetch_remote = True
+    test_f.fetch_remote = True
+    remote_f.fetch_remote = True
+    # remote_f.id is the full URI, which by default is interpreted as a local
+    # path (with a top-level "https:" directory etc.). The id cannot be
+    # changed, so if we want the file stored in the output crate with its
+    # basename we have to set localPath, which overrides the id as destination
+    remote_f["localPath"] = "sample_file.txt"
+    shutil.rmtree(out_path)
+    crate.write(out_path)
+    assert (out_path / "ro-crate-preview.html").is_file()
+    assert (out_path / test_fn).is_file()
+    assert (out_path / "sample_file.txt").is_file()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -945,3 +945,29 @@ def test_from_uri(tmpdir):
     assert (out_path / "ro-crate-preview.html").is_file()
     assert (out_path / test_fn).is_file()
     assert (out_path / "sample_file.txt").is_file()
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_from_uri_detached(tmpdir):
+    source = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+              "detached_test_data/test/test-data/detached-ro-crate-metadata.json")
+    base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+                "detached_test_data/test/test-data/")
+    crate = ROCrate(source)
+    assert crate.source == source
+    assert crate.root_dataset.id == base_uri
+    sample_file = crate.get(f"{base_uri}sample_file.txt")
+    assert sample_file.source == f"{base_uri}sample_file.txt"
+    test_file_galaxy = crate.get(f"{base_uri}test_file_galaxy.txt")
+    assert test_file_galaxy.source == f"{base_uri}test_file_galaxy.txt"
+    assert test_file_galaxy.get("localPath") == "test-data/test_file_galaxy.txt"
+    out_path = tmpdir / "out_crate"
+    crate.write(out_path)
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    assert not (out_path / "sample_file.txt").exists()
+    assert not (out_path / "test_file_galaxy.txt").exists()
+    assert not (out_path / "test-data" / "test_file_galaxy.txt").exists()
+    test_file_galaxy.fetch_remote = True
+    shutil.rmtree(out_path)
+    crate.write(out_path)
+    assert (out_path / "test-data" / "test_file_galaxy.txt").exists()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -240,7 +240,6 @@ def test_crate_with_subcrates(test_data_dir):
     assert subcrate._crate is nested_crate
 
 
-@pytest.mark.filterwarnings("ignore")
 def test_detached_crate_with_subcrates(test_data_dir):
     main_crate = ROCrate(
         test_data_dir / "detached_crate_with_subcrates/subcrates-ro-crate-metadata.json",
@@ -927,7 +926,6 @@ def test_not_data_entity_linked(version):
         assert f1 in crate.data_entities
 
 
-@pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("source_base", [
     "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
     f"file:///{THIS_DIR}/"  # extra slash needed on some windows systems
@@ -985,7 +983,6 @@ def test_from_uri(tmpdir, source_base):
     assert rremote_f_uri.get("localPath") == "sample_file.txt"
 
 
-@pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("source_base", [
     "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
     f"file:///{THIS_DIR}/"  # extra slash needed on some windows systems

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -240,6 +240,25 @@ def test_crate_with_subcrates(test_data_dir):
     assert subcrate._crate is nested_crate
 
 
+@pytest.mark.filterwarnings("ignore")
+def test_detached_crate_with_subcrates(test_data_dir):
+    main_crate = ROCrate(
+        test_data_dir / "detached_crate_with_subcrates/subcrates-ro-crate-metadata.json",
+        load_subcrates=True
+    )
+    subcrate = main_crate.get("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/")
+    assert isinstance(subcrate, Subcrate)
+    assert set(main_crate.subcrate_entities) == {subcrate}
+    assert subcrate.get("conformsTo") == "https://w3id.org/ro/crate"
+    assert subcrate._crate is None
+    other_crate = subcrate.get_crate()
+    assert isinstance(other_crate, ROCrate)
+    assert subcrate._crate is other_crate
+    assert other_crate.get(
+        "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/test-data/test_file_galaxy.txt"
+    )
+
+
 @pytest.mark.parametrize("override", [False, True])
 def test_init(test_data_dir, tmpdir, helpers, override):
     crate_dir = test_data_dir / "ro-crate-galaxy-sortchangecase"

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -32,7 +32,7 @@ from rocrate.model import DataEntity, ContextEntity, File, Dataset
 
 _URL = ('https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/'
         'test/test-data/sample_file.txt')
-THIS_DIR = Path(__file__).absolute().parent
+THIS_DIR = Path(__file__).resolve().parent
 
 
 @pytest.mark.parametrize("gen_preview,from_zip", [(False, False), (True, False), (True, True)])
@@ -911,7 +911,7 @@ def test_not_data_entity_linked(version):
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("source_base", [
     "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
-    f"file://{THIS_DIR}/"
+    f"file:///{THIS_DIR}/"  # extra slash needed on some windows systems
 ])
 def test_from_uri(tmpdir, source_base):
     source = f"{source_base}test-data/read_crate/ro-crate-metadata.json"
@@ -969,7 +969,7 @@ def test_from_uri(tmpdir, source_base):
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("source_base", [
     "https://raw.githubusercontent.com/ResearchObject/ro-crate-py/master/test/",
-    f"file://{THIS_DIR}/"
+    f"file:///{THIS_DIR}/"  # extra slash needed on some windows systems
 ])
 def test_from_uri_detached(tmpdir, source_base):
     source = f"{source_base}test-data/detached-ro-crate-metadata.json"

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -966,9 +966,9 @@ def test_from_uri(tmpdir):
 @pytest.mark.filterwarnings("ignore")
 def test_from_uri_detached(tmpdir):
     source = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
-              "detached_test_data/test/test-data/detached-ro-crate-metadata.json")
+              "master/test/test-data/detached-ro-crate-metadata.json")
     base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
-                "detached_test_data/test/test-data/")
+                "master/test/test-data/")
     crate = ROCrate(source)
     assert crate.source == source
     assert crate.root_dataset.id == base_uri

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1007,3 +1007,53 @@ def test_from_uri_detached(tmpdir, source_base):
     assert set(rcrate.data_entities) == {rsample_file, rtest_file_galaxy}
     license = rcrate.get("http://spdx.org/licenses/CC0-1.0")
     assert set(rcrate.contextual_entities) == {license}
+
+
+def test_from_file(test_data_dir, tmpdir):
+    source = test_data_dir / "read_crate" / "ro-crate-metadata.json"
+    base_path = test_data_dir / "read_crate"
+    remote_f_uri = ("https://raw.githubusercontent.com/ResearchObject/"
+                    "ro-crate-py/master/test/test-data/sample_file.txt")
+    test_fn = "test_file_galaxy.txt"
+    crate = ROCrate(source)
+    assert crate.source == source
+    assert crate.preview.source == base_path / "ro-crate-preview.html"
+    assert crate.preview.id == "ro-crate-preview.html"
+    assert test_fn in crate
+    test_f = crate.get(test_fn)
+    assert test_f.source == base_path / test_fn
+    assert test_f.id == test_fn
+    remote_f = crate.get(remote_f_uri)
+    assert remote_f.source == remote_f_uri
+    assert remote_f.id == remote_f_uri
+    out_path = tmpdir / "out_crate"
+    crate.write(out_path)
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    assert (out_path / "ro-crate-preview.html").exists()
+    assert (out_path / test_fn).exists()
+    assert not (out_path / remote_f_uri.rsplit("/", 1)[1]).exists()
+    rcrate = ROCrate(out_path)
+    assert rcrate.preview.id == "ro-crate-preview.html"
+    assert rcrate.get(test_fn)
+    assert rcrate.get(remote_f_uri)
+    assert rcrate.get("test/")
+    assert not rcrate.get("test/test-metadata.json")
+
+
+def test_from_file_detached(test_data_dir, tmpdir):
+    source = test_data_dir / "detached-ro-crate-metadata.json"
+    base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+                "master/test/test-data/")
+    crate = ROCrate(source)
+    assert crate.source == source
+    assert crate.root_dataset.id == base_uri
+    sample_file = crate.get(f"{base_uri}sample_file.txt")
+    assert sample_file.source == f"{base_uri}sample_file.txt"
+    test_file_galaxy = crate.get(f"{base_uri}test_file_galaxy.txt")
+    assert test_file_galaxy.source == f"{base_uri}test_file_galaxy.txt"
+    out_path = tmpdir / "out_crate"
+    crate.write(out_path)
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    rcrate = ROCrate(out_path)
+    assert rcrate.get(f"{base_uri}sample_file.txt")
+    assert rcrate.get(f"{base_uri}test_file_galaxy.txt")

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1191,3 +1191,61 @@ def test_read_remote_dir_local_path(tmpdir):
     assert (out_path / "errorpages" / "404.html").is_file()
     assert not (out_path / "errorpages" / "500.html").exists()
     assert (out_path / "errorpages" / "500" / "500.html").is_file()
+
+
+def test_read_remote_dir_skip_dir_part(tmpdir):
+    base_uri = "https://ftp.mozilla.org/pub/"
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.2/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "about": {"@id": base_uri},
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.2"}
+            },
+            {
+                "@id": base_uri,
+                "@type": "Dataset",
+                "datePublished": "2026-02-19",
+                "hasPart": [{"@id": f"{base_uri}misc/"}]
+            },
+            {
+                "@id": f"{base_uri}misc/",
+                "@type": "Dataset",
+                "hasPart": [
+                    # part is dir, should not try to download anything
+                    {"@id": f"{base_uri}misc/errorpages/"},
+                ]
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/",
+                "@type": "Dataset",
+                "hasPart": [
+                    {"@id": f"{base_uri}misc/errorpages/404.html"},
+                    {"@id": f"{base_uri}misc/errorpages/500.html"}
+                ]
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/404.html",
+                "@type": "File"
+            },
+            {
+                "@id": f"{base_uri}misc/errorpages/500.html",
+                "@type": "File"
+            }
+        ]
+    }
+    crate = ROCrate(metadata)
+    misc = crate.get(f"{base_uri}misc/")
+    misc.fetch_remote = True
+    errorpages = crate.get(f"{base_uri}misc/errorpages/")
+    errorpages.fetch_remote = True
+    out_path = tmpdir / 'out_crate'
+    crate.write(out_path)
+
+    assert (out_path / "ro-crate-metadata.json").is_file()
+    assert (out_path / "misc").is_dir()
+    assert (out_path / "misc" / "errorpages").is_dir()
+    assert (out_path / "misc" / "errorpages" / "404.html").is_file()
+    assert (out_path / "misc" / "errorpages" / "500.html").is_file()

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -668,7 +668,7 @@ def test_from_dict(tmpdir, version):
         ROCrate(metadata, init=True)
 
 
-def test_detached(tmpdir):
+def test_from_dict_remote_uris(tmpdir):
     base_uri = "http://example.com/"
     metadata = {
         "@context": "https://w3id.org/ro/crate/1.2/context",
@@ -913,6 +913,7 @@ def test_from_uri(tmpdir):
               "master/test/test-data/read_crate/ro-crate-metadata.json")
     base_uri = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
                 "master/test/test-data/read_crate/")
+    # this is an absolute URI in the metadata, note it's outside the crate
     remote_f_uri = ("https://raw.githubusercontent.com/ResearchObject/"
                     "ro-crate-py/master/test/test-data/sample_file.txt")
     test_fn = "test_file_galaxy.txt"
@@ -923,15 +924,22 @@ def test_from_uri(tmpdir):
     assert test_fn in crate
     test_f = crate.get(test_fn)
     assert test_f.source == base_uri + test_fn
+    assert test_f.id == test_fn
     remote_f = crate.get(remote_f_uri)
     assert remote_f.source == remote_f_uri
     assert remote_f.id == remote_f_uri
     out_path = tmpdir / "out_crate"
     crate.write(out_path)
     assert (out_path / "ro-crate-metadata.json").is_file()
+    # fetch_remote is False by default, so nothing is fetched
     assert not (out_path / "ro-crate-preview.html").exists()
     assert not (out_path / test_fn).exists()
     assert not (out_path / remote_f_uri.rsplit("/", 1)[1]).exists()
+    rcrate = ROCrate(out_path)
+    assert rcrate.preview.id == "ro-crate-preview.html"
+    assert rcrate.get(test_fn)
+    assert rcrate.get(remote_f_uri)
+    # now set some fetch_remote to True
     crate.preview.fetch_remote = True
     test_f.fetch_remote = True
     remote_f.fetch_remote = True
@@ -945,6 +953,14 @@ def test_from_uri(tmpdir):
     assert (out_path / "ro-crate-preview.html").is_file()
     assert (out_path / test_fn).is_file()
     assert (out_path / "sample_file.txt").is_file()
+    rcrate = ROCrate(out_path)
+    assert rcrate.preview.id == "ro-crate-preview.html"
+    rtest_f = rcrate.get(test_fn)
+    assert rtest_f
+    assert rtest_f.get("contentUrl") == base_uri + test_fn
+    rremote_f_uri = rcrate.get(remote_f_uri)
+    assert rremote_f_uri
+    assert rremote_f_uri.get("localPath") == "sample_file.txt"
 
 
 @pytest.mark.filterwarnings("ignore")
@@ -966,8 +982,22 @@ def test_from_uri_detached(tmpdir):
     assert (out_path / "ro-crate-metadata.json").is_file()
     assert not (out_path / "sample_file.txt").exists()
     assert not (out_path / "test_file_galaxy.txt").exists()
+    # fetch_remote is False, so file is not fetched even if localPath is set
     assert not (out_path / "test-data" / "test_file_galaxy.txt").exists()
+    rcrate = ROCrate(out_path)
+    assert rcrate.get(f"{base_uri}sample_file.txt")
+    assert rcrate.get(f"{base_uri}test_file_galaxy.txt")
+    # now set fetch_remote to True
     test_file_galaxy.fetch_remote = True
     shutil.rmtree(out_path)
     crate.write(out_path)
-    assert (out_path / "test-data" / "test_file_galaxy.txt").exists()
+    assert (out_path / "test-data" / "test_file_galaxy.txt").is_file()
+    rcrate = ROCrate(out_path)
+    rsample_file = rcrate.get(f"{base_uri}sample_file.txt")
+    rtest_file_galaxy = rcrate.get(f"{base_uri}test_file_galaxy.txt")
+    assert rtest_file_galaxy
+    assert rtest_file_galaxy.get("contentUrl") == f"{base_uri}test_file_galaxy.txt"
+    assert rtest_file_galaxy.get("localPath") == "test-data/test_file_galaxy.txt"
+    assert set(rcrate.data_entities) == {rsample_file, rtest_file_galaxy}
+    license = rcrate.get("http://spdx.org/licenses/CC0-1.0")
+    assert set(rcrate.contextual_entities) == {license}

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -758,6 +758,22 @@ def test_detached_creation(tmpdir, to_zip):
     rp = crate.get(orcid)
     assert rp["name"] == name
 
+    detached_md_path = tmpdir / "example-ro-crate-metadata.json"
+    crate.write_detached(detached_md_path)
+    assert detached_md_path.is_file()
+    rcrate = ROCrate(detached_md_path)
+    assert rcrate.source == detached_md_path
+    assert rcrate.metadata.source == "ro-crate-metadata.json"
+    assert rcrate.root_dataset.id == base_uri
+    assert rcrate.metadata.id == "ro-crate-metadata.json"
+    assert rcrate.metadata["about"] is rcrate.root_dataset
+    rd1 = rcrate.get(f"{base_uri}d1")
+    assert rd1
+    rf1 = rcrate.get(f"{base_uri}f1")
+    assert rf1
+    rp = crate.get(orcid)
+    assert rp["name"] == name
+
     with pytest.raises(ValueError):
         ROCrate(root_dataset_id="foo/bar")
     with pytest.raises(ValueError):

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -281,8 +281,8 @@ def test_remote_dir(tmpdir, helpers, fetch_remote, validate_url):
     relpath = "pub/misc/errorpages/"
     properties = {
         "hasPart": [
-            {"@id": "404.html"},
-            {"@id": "500.html"},
+            {"@id": "https://ftp.mozilla.org/pub/misc/errorpages/404.html"},
+            {"@id": "https://ftp.mozilla.org/pub/misc/errorpages/500.html"},
         ],
     }
     kw = {
@@ -305,7 +305,8 @@ def test_remote_dir(tmpdir, helpers, fetch_remote, validate_url):
         out_dataset = out_crate.dereference(relpath)
         assert (out_path / relpath).is_dir()
         for entry in properties["hasPart"]:
-            assert (out_path / relpath / entry["@id"]).is_file()
+            basename = entry["@id"].rsplit("/", 1)[-1]
+            assert (out_path / relpath / basename).is_file()
     else:
         out_dataset = out_crate.dereference(url)
         assert not (out_path / relpath).exists()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -177,6 +177,25 @@ def test_remote_uri(tmpdir, helpers, fetch_remote, validate_url, to_zip):
             assert "sdDatePublished" in props
 
 
+def test_local_path(test_data_dir, tmpdir):
+    crate = ROCrate()
+    url = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+           "master/test/test-data/sample_file.txt")
+    sample_file = crate.add_file(url)
+    assert sample_file.id == url
+    sample_file["localPath"] = "test-data/sample_file.txt"
+    sample_file.fetch_remote = True
+    test_file_galaxy = crate.add_file(test_data_dir / "test_file_galaxy.txt")
+    assert test_file_galaxy.id == "test_file_galaxy.txt"
+    test_file_galaxy["localPath"] = "foo/bar.txt"
+    out_path = tmpdir / "ro_crate_out"
+    crate.write(out_path)
+    assert (out_path / "test-data" / "sample_file.txt").is_file()
+    assert not (out_path / "sample_file.txt").exists()
+    assert not (out_path / "foo" / "bar.txt").exists()
+    assert (out_path / "test_file_galaxy.txt").is_file()
+
+
 def test_file_uri(tmpdir):
     f_name = uuid.uuid4().hex
     f_path = (tmpdir / f_name).resolve()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -197,6 +197,40 @@ def test_local_path(test_data_dir, tmpdir):
     assert (out_path / "test_file_galaxy.txt").is_file()
 
 
+def test_local_path_vs_relative_id(test_data_dir, tmpdir):
+    crate = ROCrate()
+    url = ("https://raw.githubusercontent.com/ResearchObject/ro-crate-py/"
+           "master/test/test-data/sample_file.txt")
+    sample_file = crate.add_file(url, dest_path="examples/sample_file.txt")
+    assert sample_file.id == "examples/sample_file.txt"
+    sample_file["localPath"] = "test-data/sample_file.txt"
+    sample_file.fetch_remote = True
+    out_path = tmpdir / "ro_crate_out"
+    crate.write(out_path)
+    assert (out_path / "examples" / "sample_file.txt").is_file()
+    assert not (out_path / "test-data" / "sample_file.txt").exists()
+
+
+def test_local_path_vs_relative_id_dataset(test_data_dir, tmpdir):
+    crate = ROCrate()
+    f1 = crate.add_file("https://ftp.mozilla.org/pub/misc/errorpages/404.html")
+    f2 = crate.add_file("https://ftp.mozilla.org/pub/misc/errorpages/500.html")
+    dataset = crate.add_dataset(
+        "https://ftp.mozilla.org/pub/misc/errorpages/",
+        dest_path="errorpages/",
+        fetch_remote=True,
+    )
+    assert dataset.id == "errorpages/"
+    dataset["hasPart"] = [f1, f2]
+    dataset["localPath"] = "mozilla_error_pages"
+    out_path = tmpdir / "ro_crate_out"
+    crate.write(out_path)
+    assert (out_path / "errorpages").is_dir()
+    assert (out_path / "errorpages" / "404.html").is_file()
+    assert (out_path / "errorpages" / "500.html").is_file()
+    assert not (out_path / "mozilla_error_pages").exists()
+
+
 def test_file_uri(tmpdir):
     f_name = uuid.uuid4().hex
     f_path = (tmpdir / f_name).resolve()

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -806,13 +806,20 @@ def test_detached_creation(tmpdir, to_zip):
     assert rcrate.root_dataset.id == base_uri
     assert rcrate.metadata.id == "ro-crate-metadata.json"
     assert rcrate.metadata["about"] is rcrate.root_dataset
-    rd1 = rcrate.get(f"{base_uri}d1")
-    assert rd1
-    rf1 = rcrate.get(f"{base_uri}f1")
-    assert rf1
+    assert rcrate.get(f"{base_uri}d1")
+    assert rcrate.get(f"{base_uri}f1")
     rp = rcrate.get(orcid)
     assert rp["name"] == name
 
+
+def test_detached_creation_write_detached(tmpdir):
+    base_uri = "http://example.com/crate/"
+    orcid = "https://orcid.org/0000-0002-1825-0097"
+    name = "Josiah Carberry"
+    crate = ROCrate(root_dataset_id=base_uri)
+    crate.add_dataset(f"{base_uri}d1")
+    crate.add_file(f"{base_uri}f1")
+    crate.add(Person(crate, orcid, properties={"name": name}))
     detached_md_path = tmpdir / "example-ro-crate-metadata.json"
     crate.write_detached(detached_md_path)
     assert detached_md_path.is_file()
@@ -822,13 +829,13 @@ def test_detached_creation(tmpdir, to_zip):
     assert rcrate.root_dataset.id == base_uri
     assert rcrate.metadata.id == "ro-crate-metadata.json"
     assert rcrate.metadata["about"] is rcrate.root_dataset
-    rd1 = rcrate.get(f"{base_uri}d1")
-    assert rd1
-    rf1 = rcrate.get(f"{base_uri}f1")
-    assert rf1
+    assert rcrate.get(f"{base_uri}d1")
+    assert rcrate.get(f"{base_uri}f1")
     rp = rcrate.get(orcid)
     assert rp["name"] == name
 
+
+def test_detached_creation_exceptions():
     with pytest.raises(ValueError):
         ROCrate(root_dataset_id="foo/bar")
     with pytest.raises(ValueError):

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -755,7 +755,7 @@ def test_detached_creation(tmpdir, to_zip):
     assert rd1
     rf1 = rcrate.get(f"{base_uri}f1")
     assert rf1
-    rp = crate.get(orcid)
+    rp = rcrate.get(orcid)
     assert rp["name"] == name
 
     detached_md_path = tmpdir / "example-ro-crate-metadata.json"
@@ -771,7 +771,7 @@ def test_detached_creation(tmpdir, to_zip):
     assert rd1
     rf1 = rcrate.get(f"{base_uri}f1")
     assert rf1
-    rp = crate.get(orcid)
+    rp = rcrate.get(orcid)
     assert rp["name"] == name
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
Closes #231.
Closes #232.

Adds several new features to support [detached crates](https://www.researchobject.org/ro-crate/specification/1.2/structure.html#types-of-ro-crate):

* More testing for reading a crate from a JSON dictionary, which was [already supported](https://github.com/ResearchObject/ro-crate-py/pull/183). This is one of the ways to read a detached crate
* Much simpler algorithm to find the metadata descriptor and root data entity -- the previous one was based on a version of the 1.2 draft that does not exist anymore (see https://github.com/ResearchObject/ro-crate/pull/198).
* Support for _creating_ a detached crate from scratch: the `ROCrate` initializer now accepts a `root_dataset_id` argument to specify an arbitrary absolute URI
* Support for reading a crate from a remote or local (`file://`) URL
* Support for reading a crate from a local metadata file
* Support for writing an RO-Crate as detached (write only the metadata file, with a custom name)
* Support referencing detached crates as "subcrates"

Note I didn't add any `is_detached` or similar property: the distinction between attached and detached is quite subtle, and being one or the other depends on the current state of the crate in memory. For instance, if you add a data entity with a relative URI to a crate that had only web-based data entities, it won't be detached anymore.
