### PR TITLE
Fix UTF-8 representation of non-ASCII characters

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,6 +34,9 @@ authors:
   - family-names: Leo
     given-names: Simone
     orcid: https://orcid.org/0000-0001-8271-5429
+  - family-names: Orviz
+    given-names: Pablo
+    orcid: https://orcid.org/0000-0002-2473-6405
   - family-names: Pireddu
     given-names: Luca
     orcid: https://orcid.org/0000-0002-4663-5613

--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ Options:
 * Copyright 2024-2026 National Institute of Informatics (NII), JP
 * Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 * Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+* Copyright 2026 Spanish National Research Council (CSIC), ES
 
 Licensed under the
 Apache License, version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>,

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/read_test_metadata.py
+++ b/examples/read_test_metadata.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +43,7 @@ __author__ = ", ".join((
     'Sebastiaan Huber',
     'Bruno Kinoshita',
     'Simone Leo',
+    'Pablo Orviz',
     'Luca Pireddu',
     'Laura Rodríguez-Navas',
     'Raül Sirvent',
@@ -58,6 +60,7 @@ Copyright 2024-2026 Data Centre, SciLifeLab, SE
 Copyright 2024-2026 National Institute of Informatics (NII), JP
 Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+Copyright 2026 Spanish National Research Council (CSIC), ES
 """
 __license__ = ("Apache License, version 2.0 "
                "<https://www.apache.org/licenses/LICENSE-2.0>")

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/memory_buffer.py
+++ b/rocrate/memory_buffer.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/__init__.py
+++ b/rocrate/model/__init__.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/computationalworkflow.py
+++ b/rocrate/model/computationalworkflow.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/computerlanguage.py
+++ b/rocrate/model/computerlanguage.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/contextentity.py
+++ b/rocrate/model/contextentity.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/creativework.py
+++ b/rocrate/model/creativework.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/data_entity.py
+++ b/rocrate/model/data_entity.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/file_or_dir.py
+++ b/rocrate/model/file_or_dir.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -88,7 +88,7 @@ class Metadata(File):
 
     def stream(self, chunk_size=8192):
         content = self.generate()
-        yield self.id, str.encode(json.dumps(content, indent=4, sort_keys=True), encoding='utf-8')
+        yield self.id, str.encode(json.dumps(content, indent=4, sort_keys=True, ensure_ascii=False), encoding='utf-8')
 
     def _has_writeable_stream(self):
         return True

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/person.py
+++ b/rocrate/model/person.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/preview.py
+++ b/rocrate/model/preview.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/root_dataset.py
+++ b/rocrate/model/root_dataset.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/softwareapplication.py
+++ b/rocrate/model/softwareapplication.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testdefinition.py
+++ b/rocrate/model/testdefinition.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testinstance.py
+++ b/rocrate/model/testinstance.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testservice.py
+++ b/rocrate/model/testservice.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testsuite.py
+++ b/rocrate/model/testsuite.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/utils.py
+++ b/rocrate/utils.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/vocabs.py
+++ b/rocrate/vocabs.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,6 +71,7 @@ setup(
         'Sebastiaan Huber',
         'Bruno Kinoshita',
         'Simone Leo',
+        'Pablo Orviz',
         'Luca Pireddu',
         'Laura Rodríguez-Navas',
         'Raül Sirvent',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_readwrite.py
+++ b/test/test_readwrite.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_test_metadata.py
+++ b/test/test_test_metadata.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_workflow_ro_crate.py
+++ b/test/test_workflow_ro_crate.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -716,3 +716,45 @@ def test_write_version(tmpdir, helpers, version):
     with open(out_path / basename, "rt") as f:
         data = json.load(f)
     assert data["@context"] == f"https://w3id.org/ro/crate/{version}/context"
+
+
+def test_metadata_utf8_encoding(tmpdir, helpers):
+    crate = ROCrate()
+    crate_name = 'Test crate with non-ASCII characters'
+    crate.name = crate_name
+    creator_name = 'Orviz Fernández'
+    creator_affiliation = 'Consejo Superior de Investigaciones Científicas (CSIC)'
+    non_ascii_person_name = Person(
+        crate,
+        "https://orcid.org/0000-0000-0000-0000",
+        {
+            'name': creator_name,
+            'affiliation': creator_affiliation
+        }
+    )
+    crate.add(non_ascii_person_name)
+
+    out_path = tmpdir / 'ro_crate_out'
+    out_path.mkdir()
+    crate.write(out_path)
+
+    metadata_path = out_path / helpers.METADATA_FILE_NAME
+    assert metadata_path.exists()
+
+    with open(metadata_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    assert creator_name in content, (
+        f"Creator name '{creator_name}' as found in {helpers.METADATA_FILE_NAME} does not match with the real name: "
+        "not found as raw UTF-8 text or incorrectly encoded"
+    )
+    assert creator_affiliation in content, (
+        f"Creator affiliation '{creator_affiliation}' as found in {helpers.METADATA_FILE_NAME} "
+        "does not match with the real organization name: not found as raw UTF-8 text or incorrectly encoded"
+    )
+    import re
+    unicode_escape_pattern = r"\\u[0-9a-fA-F]{4}"
+    escape_sequences_match = re.findall(unicode_escape_pattern, content)
+    assert not escape_sequences_match, (
+        f"Found Unicode escape sequences: {escape_sequences_match}: expected raw UTF-8 characters."
+    )

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/add_boilerplate.py
+++ b/tools/add_boilerplate.py
@@ -7,6 +7,7 @@
 # Copyright 2024-2026 National Institute of Informatics (NII), JP
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
+# Copyright 2026 Spanish National Research Council (CSIC), ES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,6 +44,7 @@ START_YEAR_MAP = {
     "National Institute of Informatics (NII), JP": "2024",
     "Senckenberg Society for Nature Research (SGN), DE": "2025",
     "European Molecular Biology Laboratory (EMBL), Heidelberg, DE": "2025",
+    "Spanish National Research Council (CSIC), ES": "2026",
 }
 THIS_YEAR = str(datetime.date.today().year)
 BOILERPLATE_START = "Copyright [yyyy] [name of copyright owner]"


### PR DESCRIPTION
Closes #251: add `ensure_ascii=False` to the `json.dumps` call to ensure raw UTF-8 representation of non-ASCII chars.

I have structured this PR in two commits to follow a TDD approach:
- The first commit adds a failing test case that asserts correct UTF-8 representation.
- The second commit provides the fix.

You can verify the assert errors by checking out the first commit and running the new test.