### PR TITLE
Fix: Pass through `version` in `init=True` case

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,6 +31,9 @@ authors:
   - family-names: Kinoshita
     given-names: Bruno
     orcid: https://orcid.org/0000-0001-8250-4074
+  - family-names: Lenz
+    given-names: Julian
+    orcid: https://orcid.org/0000-0001-5250-0005
   - family-names: Leo
     given-names: Simone
     orcid: https://orcid.org/0000-0001-8271-5429

--- a/README.md
+++ b/README.md
@@ -628,6 +628,7 @@ Options:
 * Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 * Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 * Copyright 2026 Spanish National Research Council (CSIC), ES
+* Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 
 Licensed under the
 Apache License, version 2.0 <https://www.apache.org/licenses/LICENSE-2.0>,

--- a/examples/fastapi/main.py
+++ b/examples/fastapi/main.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/read_test_metadata.py
+++ b/examples/read_test_metadata.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/__init__.py
+++ b/rocrate/__init__.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +43,7 @@ __author__ = ", ".join((
     'Matthias Hörtenhuber',
     'Sebastiaan Huber',
     'Bruno Kinoshita',
+    'Julian Lenz',
     'Simone Leo',
     'Pablo Orviz',
     'Luca Pireddu',
@@ -61,6 +63,7 @@ Copyright 2024-2026 National Institute of Informatics (NII), JP
 Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 Copyright 2026 Spanish National Research Council (CSIC), ES
+Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 """
 __license__ = ("Apache License, version 2.0 "
                "<https://www.apache.org/licenses/LICENSE-2.0>")

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/cli.py
+++ b/rocrate/cli.py
@@ -93,9 +93,15 @@ def cli():
     metavar="NAME",
     help="Exclude files or directories from the metadata file. NAME may be a single name or a comma-separated list of names.",
 )
+@click.option(
+    "--crate-version",
+    default="1.2",
+    type=str,
+    help="Version of the RO-Crate standard to initialize the crate with.",
+)
 @OPTION_CRATE_PATH
-def init(crate_dir, gen_preview, exclude):
-    crate = ROCrate(crate_dir, init=True, gen_preview=gen_preview, exclude=exclude)
+def init(crate_dir, gen_preview, exclude, crate_version):
+    crate = ROCrate(crate_dir, init=True, gen_preview=gen_preview, exclude=exclude, version=crate_version)
     crate.metadata.write(crate_dir)
     if crate.preview:
         crate.preview.write(crate_dir)

--- a/rocrate/memory_buffer.py
+++ b/rocrate/memory_buffer.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/metadata.py
+++ b/rocrate/metadata.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/__init__.py
+++ b/rocrate/model/__init__.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/computationalworkflow.py
+++ b/rocrate/model/computationalworkflow.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/computerlanguage.py
+++ b/rocrate/model/computerlanguage.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/contextentity.py
+++ b/rocrate/model/contextentity.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/creativework.py
+++ b/rocrate/model/creativework.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/data_entity.py
+++ b/rocrate/model/data_entity.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/dataset.py
+++ b/rocrate/model/dataset.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/entity.py
+++ b/rocrate/model/entity.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/file.py
+++ b/rocrate/model/file.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/file_or_dir.py
+++ b/rocrate/model/file_or_dir.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/metadata.py
+++ b/rocrate/model/metadata.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/person.py
+++ b/rocrate/model/person.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/preview.py
+++ b/rocrate/model/preview.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/root_dataset.py
+++ b/rocrate/model/root_dataset.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/softwareapplication.py
+++ b/rocrate/model/softwareapplication.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testdefinition.py
+++ b/rocrate/model/testdefinition.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testinstance.py
+++ b/rocrate/model/testinstance.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testservice.py
+++ b/rocrate/model/testservice.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/model/testsuite.py
+++ b/rocrate/model/testsuite.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -150,7 +150,7 @@ class ROCrate():
             self.mode = Mode.INIT
             if isinstance(source, dict):
                 raise ValueError("parameter 'init' is not compatible with a dict source")
-            self.__init_from_tree(source, gen_preview=gen_preview)
+            self.__init_from_tree(source, gen_preview=gen_preview, version=version)
         else:
             self.mode = Mode.READ
             source = self.__read(source, gen_preview=gen_preview)

--- a/rocrate/utils.py
+++ b/rocrate/utils.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rocrate/vocabs.py
+++ b/rocrate/vocabs.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,6 +71,7 @@ setup(
         'Matthias Hörtenhuber',
         'Sebastiaan Huber',
         'Bruno Kinoshita',
+        'Julian Lenz',
         'Simone Leo',
         'Pablo Orviz',
         'Luca Pireddu',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -121,6 +121,23 @@ def test_cli_init(test_data_dir, helpers, monkeypatch, cwd, gen_preview):
     assert json_entities["sort-and-change-case.ga"]["@type"] == "File"
 
 
+@pytest.mark.parametrize("version", ["1.0", "1.1"])
+def test_cli_init_version(test_data_dir, helpers, version):
+    crate_dir = test_data_dir / "ro-crate-galaxy-sortchangecase"
+    metadata_path = crate_dir / helpers.METADATA_FILE_NAME
+    metadata_path.unlink()
+    args = ["init", "-c", str(crate_dir), "--crate-version", version]
+
+    CliRunner().invoke(cli, args)
+
+    # The metadata filename changed from `*.jsonld` to `*.json`.
+    # Handling earlier versions, we must be flexible here.
+    # The `next(...)` call might fail with `StopIteration` if the file is missing.
+    # But if so, this is just another test failure.
+    with next(metadata_path.parent.glob(f"{str(metadata_path.name)}*")).open("r") as file:
+        assert json.load(file)["@context"] == f"https://w3id.org/ro/crate/{version}/context"
+
+
 def test_cli_init_exclude(test_data_dir, helpers):
     crate_dir = test_data_dir / "ro-crate-galaxy-sortchangecase"
     (crate_dir / helpers.METADATA_FILE_NAME).unlink()

--- a/test/test_jsonld.py
+++ b/test/test_jsonld.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_readwrite.py
+++ b/test/test_readwrite.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_test_metadata.py
+++ b/test/test_test_metadata.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_workflow_ro_crate.py
+++ b/test/test_workflow_ro_crate.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/test_wrroc.py
+++ b/test/test_wrroc.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/add_boilerplate.py
+++ b/tools/add_boilerplate.py
@@ -8,6 +8,7 @@
 # Copyright 2025-2026 Senckenberg Society for Nature Research (SGN), DE
 # Copyright 2025-2026 European Molecular Biology Laboratory (EMBL), Heidelberg, DE
 # Copyright 2026 Spanish National Research Council (CSIC), ES
+# Copyright 2026 Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +46,7 @@ START_YEAR_MAP = {
     "Senckenberg Society for Nature Research (SGN), DE": "2025",
     "European Molecular Biology Laboratory (EMBL), Heidelberg, DE": "2025",
     "Spanish National Research Council (CSIC), ES": "2026",
+    "Helmholtz-Zentrum Dresden-Rossendorf (HZDR), DE": "2026",
 }
 THIS_YEAR = str(datetime.date.today().year)
 BOILERPLATE_START = "Copyright [yyyy] [name of copyright owner]"


### PR DESCRIPTION
Thanks for this great project! I've just started using it and it works quite well!

However, this tiny oversight had me scratching my head for quite a while: In `init=True` mode, the `version` parameter of `ROCrate.__init__` is not passed through to `__init_from_tree`.