### PR TITLE
Preserve entity IDs in missing-type errors

### DIFF
--- a/rocrate/rocrate.py
+++ b/rocrate/rocrate.py
@@ -246,8 +246,8 @@ class ROCrate():
                 if not is_data_entity(entities[id_]):
                     continue
             entity = entities.pop(id_)
-            assert id_ == entity.pop('@id')
             cls = pick_type(entity, type_map, fallback=DataEntity, load_subcrates=self.load_subcrates)
+            assert id_ == entity.pop('@id')
 
             if cls is Subcrate:
 
@@ -288,8 +288,8 @@ class ROCrate():
                     raise ValueError(f"'{id_}' is a data entity but it's not linked to from the root dataset's hasPart")
                 else:
                     warnings.warn(f"'{id_}' looks like a data entity but it's not listed in the root dataset's hasPart")
-            assert identifier == entity.pop('@id')
             cls = pick_type(entity, type_map, fallback=ContextEntity)
+            assert identifier == entity.pop('@id')
             self.add(cls(self, identifier, entity))
 
     @property

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -851,6 +851,36 @@ def test_read_version(test_data_dir):
     assert crate.version == "1.2-DRAFT"
 
 
+@pytest.mark.parametrize(("entity_id", "has_part"), [
+    ("missing-type.txt", True),
+    ("#missing-type", False),
+])
+def test_entity_without_type_reports_its_id(entity_id, has_part):
+    root = {
+        "@id": "./",
+        "@type": "Dataset",
+    }
+    if has_part:
+        root["hasPart"] = {"@id": entity_id}
+    metadata = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@id": "ro-crate-metadata.json",
+                "@type": "CreativeWork",
+                "about": {"@id": "./"},
+                "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+            },
+            root,
+            {"@id": entity_id},
+        ],
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        ROCrate(metadata)
+    assert str(exc_info.value) == f"entity {entity_id!r} has no @type"
+
+
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("version", ["1.0", "1.1", "1.2"])
 def test_data_entity_not_linked(version):


### PR DESCRIPTION
## Summary

- keep each entity's `@id` available while `pick_type` validates `@type`
- remove `@id` immediately after successful type selection, preserving normal construction behavior
- add regression coverage for both referenced data entities and contextual entities missing `@type`

Fixes #137.

## Validation

- preserved evidence for this exact base and patch: targeted regression 2 passed; adjacent local read/profile/metadata tests 20 passed; narrow flake8 check passed
- `git diff --check` and reverse-apply check passed in the current worktree

The current system environment does not have the existing `arcp` dependency, so pytest cannot collect here; no dependency was installed. A broader preserved diagnostic is not claimed as fully green because pre-existing network-dependent read tests timed out.

## AI assistance disclosure

This patch, tests, and pull request text were developed and checked with OpenAI Codex assistance. No independent human self-review is claimed; maintainer review is requested before merge.